### PR TITLE
Fix container full for 2 news templates

### DIFF
--- a/shortcodes/epfl_news/view.php
+++ b/shortcodes/epfl_news/view.php
@@ -15,8 +15,11 @@
   }
 ?>
 
-<div class="container-full">
+<?php if ("1" == $template): ?>
   <div class="container">
+<?php else: ?>
+  <div class="container-full">
+<?php endif ?>
     <div class="list-group">
       <?php
         foreach($data as $news) {
@@ -176,6 +179,5 @@
 </p>
 <?php endif; ?>
 
-</div>
 </div>
 </div>


### PR DESCRIPTION
Pour les templates news du style "highlighted", il faut que ces templates prennent toute la largeur.