### PR TITLE
Display the version number

### DIFF
--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI:
 Author: Antistatique.net
 Author URI: http://antistatique.net/
 Description: Description
-Version: 1.0.0
+Version: 2.1.0
 License: GNU General Public License v2 or later
 License URI: LICENSE
 Text Domain: epfl


### PR DESCRIPTION
Faire en sorte que l'on voit le numéro de version dans le thème. 

Cette manière de faire est temporaire, à terme, on ne va pas s'amuser à modifier à 2 endroits le numéro de version.