### PR TITLE
Name menu location, change default name from 'primary' to 'top' to match 2010 theme, prepare for footer

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -8,7 +8,10 @@
  */
 
 global $EPFL_MENU_LOCATION;
-$EPFL_MENU_LOCATION = 'primary';
+$EPFL_MENU_LOCATION = 'top';
+
+global $EPFL_FOOTER_MENU_LOCATION;
+$EPFL_FOOTER_MENU_LOCATION = 'footer_nav';
 
 if ( ! function_exists( 'epfl_setup' ) ) :
 	/**
@@ -47,8 +50,10 @@ if ( ! function_exists( 'epfl_setup' ) ) :
 
 		// This theme uses wp_nav_menu() in one location.
 		global $EPFL_MENU_LOCATION;
+		global $EPFL_FOOTER_MENU_LOCATION;
 		$nav_menus_args = [];
 		$nav_menus_args[$EPFL_MENU_LOCATION] = esc_html__( 'Primary', 'epfl' );
+		$nav_menus_args[$EPFL_FOOTER_MENU_LOCATION] = esc_html__( 'Footer', 'epfl' );
 		register_nav_menus($nav_menus_args);
 
 		/*
@@ -302,34 +307,8 @@ add_post_type_support( 'page', 'excerpt' );
  * @return string
  */
 function get_current_menu_slug() {
-	$theme_location = 'primary';
+    global $EPFL_MENU_LOCATION;
   $menu_locations = get_nav_menu_locations();
-  $menu_term = get_term($menu_locations[$theme_location], 'nav_menu');
+  $menu_term = get_term($menu_locations[$EPFL_MENU_LOCATION], 'nav_menu');
 	return $menu_term;
 }
-
-/**
- * reassign_menus()
- *
- * looks if the current installation has menus set for the nav menu.
- * If that is not the case, it looks for a menu named "fr" or "en"
- * and assigns it to the corresponding language
- *
- * @return void
- */
-function reassign_menus() {
-	global $EPFL_MENU_LOCATION;
-	if(!has_nav_menu($EPFL_MENU_LOCATION)) {
-		$theme_slug = get_option('stylesheet');
-		$polylang_options = get_option( 'polylang' );
-
-		$menus = wp_get_nav_menus();
-		foreach($menus as $menu) {
-			if ($menu->name == 'fr' || $menu->name == 'en'){
-				$polylang_options["nav_menus"][$theme_slug][$EPFL_MENU_LOCATION][$menu->name] = $menu->term_id;
-			}
-		}
-		update_option( 'polylang', $polylang_options );
-	}
-}
-add_action('init', 'reassign_menus');

--- a/header.php
+++ b/header.php
@@ -30,7 +30,10 @@
 		</a>
 
 			<?php
+			    global $EPFL_MENU_LOCATION;
 				wp_nav_menu( array(
+				    'theme_location' => $EPFL_MENU_LOCATION,
+        		    'menu_id'        => $EPFL_MENU_LOCATION.'-menu',
 					'menu_class'=> 'nav-header d-none d-xl-flex',
 					'container' => 'ul',
 					'depth' => 1

--- a/sidebar.php
+++ b/sidebar.php
@@ -9,6 +9,8 @@
 
 global $wp_query;
 
+global $EPFL_MENU_LOCATION;
+
 // recover current post and menu item
 $items = wp_get_nav_menu_items(get_current_menu_slug());
 $item = reset(wp_filter_object_list( $items, ['object_id' => $post->ID]));
@@ -23,7 +25,7 @@ if ( $item->menu_item_parent == 0 || $item === false ) $classes = 'current-menu-
 		<div class="nav-container <?php echo $classes ?>">
 			<?php
 				wp_nav_menu( array(
-					'theme_location' => 'primary',
+					'theme_location' => $EPFL_MENU_LOCATION,
 					'menu_class'=> 'nav-menu',
 					'container' => 'ul',
 					'walker' => new Custom_Nav_Walker()
@@ -49,7 +51,8 @@ if ( $item->menu_item_parent == 0 || $item === false ) $classes = 'current-menu-
   	<h2 class="h5 sr-only-xl"><?php esc_html_e("In the same section", 'epfl') ?></h2>
 				<?php
 				wp_nav_menu( array(
-					'menu_class'=> 'nav-menu',
+				    'theme_location' => $EPFL_MENU_LOCATION,
+        		    'menu_class'=> 'nav-menu',
 					'container' => 'ul',
 					'submenu' => get_the_ID(),
 					'submenu_type' => $asideContent


### PR DESCRIPTION
Réponse à l'issue https://github.com/epfl-idevelop/wp-theme-2018/issues/81

- Changement du nom de la localisation du menu principal pour passer de `primary` à `top` afin d'être en accord avec le thème 2010
- Ajout d'informations d'identification du nom du menu dans l'ajout de celui-ci dans le header et la sidebar.
- Ajout de l'enregistrement du menu `footer_nav` (même nom que thème 2010) afin de préparer à l'apparition de celui-ci dans le footer (il faudra encore l'ajouter par la suite dans `footer.php` pour dire où il s'affiche exactement).
- Utilisation partout de la variable `$EPFL_MENU_LOCATION` contenant la localisation du menu car c'était aussi codé en dur parfois.
- Suppression du code de réassignation des informations des menus "fr" et "en" car pas générique et inutile au vu de la procédure de passage de 2010 à 2018 qui a été trouvée (voir ci-dessous).

**Procédure de passage de 2010 à 2018**
Etant donné que les informations du thème relatives aux menus (valable aussi pour polylang) sont stockées dans des options suffixées avec le nom du dossier dans lequel se trouve le thème actif, il est plus simple, lorsque l'on met à jour le thème pour passer de 2010 à 2018, de simplement écraser le contenu du dossier "epfl-master" avec le contenu du nouveau thème