### PR TITLE
epfl news video mp4

### DIFF
--- a/shortcodes/epfl_news/utils.php
+++ b/shortcodes/epfl_news/utils.php
@@ -59,8 +59,7 @@ function epfl_news_get_publish_date($news) {
  * $news: news to display
  */
 function epfl_news_get_subtitle($news) {
-    $subtitle = strip_tags($news->subtitle);
-    return $subtitle;
+    return strip_tags($news->subtitle);
 }
 
 /**
@@ -69,28 +68,25 @@ function epfl_news_get_subtitle($news) {
  * $news: news to display
  */
 function epfl_news_get_visual_url($news) {
-    $visual_url = substr($news->visual_url, 0, -11) . '1296x728.jpg';
-    return $visual_url;
+    return substr($news->visual_url, 0, -11) . '1296x728.jpg';
 }
 
 /**
- * Get media url
- * 
- * $news: news to display
+ * Get attachment url by slug
  */
-function epfl_news_get_media_url($news) {
-    $slug = str_replace("https://actu.epfl.ch/news/", "", $news->news_url);
-    $video_name = "teaser_" . $slug;
-          
-    global $wpdb;
-    $attachment = $wpdb->get_col($wpdb->prepare("SELECT ID FROM $wpdb->posts WHERE post_name='%s';", esc_attr($video_name)));
+function get_attachment_url_by_slug( $slug ) {
+    
+    $args = array(
+      'post_type'      => 'attachment',
+      'name'           => sanitize_title($slug),
+      'posts_per_page' => 1,
+      'post_status'    => 'inherit',
+    );
 
-    $media_url = "";
-    if ( !is_null( $attachment ) ) {
-        $media_id = $attachment[0];
-        $media_url = wp_get_attachment_url( $media_id );  
-    }
-    return $media_url;
-}
+    $_header = get_posts( $args );
+    $header  = $_header ? array_pop($_header) : null;
+
+    return $header ? wp_get_attachment_url($header->ID) : '';
+  }
 
 ?>

--- a/shortcodes/epfl_news/utils.php
+++ b/shortcodes/epfl_news/utils.php
@@ -80,10 +80,10 @@ function get_visual_url($news) {
  */
 function get_media_url($news) {
     $slug = str_replace("https://actu.epfl.ch/news/", "", $news->news_url);
-    $video_url = "teaser_" . $slug;
+    $video_name = "teaser_" . $slug;
           
     global $wpdb;
-    $attachment = $wpdb->get_col($wpdb->prepare("SELECT ID FROM $wpdb->posts WHERE post_name='%s';", $video_url ));
+    $attachment = $wpdb->get_col($wpdb->prepare("SELECT ID FROM $wpdb->posts WHERE post_name='%s';", esc_attr($video_name)));
 
     $media_url = "";
     if ( !is_null( $attachment ) ) {

--- a/shortcodes/epfl_news/utils.php
+++ b/shortcodes/epfl_news/utils.php
@@ -1,0 +1,96 @@
+<?php 
+
+/**
+ * Get url channel
+ * 
+ * $data: all data from back-end
+ */
+function get_url_channel($data) {
+    $url_channel = "";
+    if (count($data) > 0) {
+        $channel = $data[0]->channel->name;
+        $url_channel = "https://actu.epfl.ch/search/" . $channel;
+    }
+    return $url_channel;
+}
+
+/**
+ * Get image description
+ * 
+ * $news: news to display
+ */
+function get_image_description($news) {
+    if (get_locale() == 'fr_FR') {
+        $image_description = $news->fr_description;
+    } else {
+        $image_description = $news->en_description;
+    }
+    return $image_description;
+}
+
+/**
+ * Get label category
+ * 
+ * $news: news to display
+ */
+function get_label_category($news) {
+    if (get_locale() == 'fr_FR') {
+        $label_category = $news->category->fr_label;
+    } else {
+        $label_category = $news->category->en_label;
+    }
+    return $label_category;
+}
+
+/**
+ * Get publish date
+ * 
+ * $news: news to display
+ */
+function get_publish_date($news) {
+    $publish_date = new DateTime($news->publish_date);
+    $publish_date = $publish_date->format('d.m.y');
+    return $publish_date;
+}
+
+/**
+ * Get subtitle
+ * 
+ * $news: news to display
+ */
+function get_subtitle($news) {
+    $subtitle = strip_tags($news->subtitle);
+    return $subtitle;
+}
+
+/**
+ * Get visual url
+ * 
+ * $news: news to display
+ */
+function get_visual_url($news) {
+    $visual_url = substr($news->visual_url, 0, -11) . '1296x728.jpg';
+    return $visual_url;
+}
+
+/**
+ * Get media url
+ * 
+ * $news: news to display
+ */
+function get_media_url($news) {
+    $slug = str_replace("https://actu.epfl.ch/news/", "", $news->news_url);
+    $video_url = "teaser_" . $slug;
+          
+    global $wpdb;
+    $attachment = $wpdb->get_col($wpdb->prepare("SELECT ID FROM $wpdb->posts WHERE post_name='%s';", $video_url ));
+
+    $media_url = "";
+    if ( !is_null( $attachment ) ) {
+        $media_id = $attachment[0];
+        $media_url = wp_get_attachment_url( $media_id );  
+    }
+    return $media_url;
+}
+
+?>

--- a/shortcodes/epfl_news/utils.php
+++ b/shortcodes/epfl_news/utils.php
@@ -5,7 +5,7 @@
  * 
  * $data: all data from back-end
  */
-function get_url_channel($data) {
+function epfl_news_get_url_channel($data) {
     $url_channel = "";
     if (count($data) > 0) {
         $channel = $data[0]->channel->name;
@@ -19,7 +19,7 @@ function get_url_channel($data) {
  * 
  * $news: news to display
  */
-function get_image_description($news) {
+function epfl_news_get_image_description($news) {
     if (get_locale() == 'fr_FR') {
         $image_description = $news->fr_description;
     } else {
@@ -33,7 +33,7 @@ function get_image_description($news) {
  * 
  * $news: news to display
  */
-function get_label_category($news) {
+function epfl_news_get_label_category($news) {
     if (get_locale() == 'fr_FR') {
         $label_category = $news->category->fr_label;
     } else {
@@ -47,7 +47,7 @@ function get_label_category($news) {
  * 
  * $news: news to display
  */
-function get_publish_date($news) {
+function epfl_news_get_publish_date($news) {
     $publish_date = new DateTime($news->publish_date);
     $publish_date = $publish_date->format('d.m.y');
     return $publish_date;
@@ -58,7 +58,7 @@ function get_publish_date($news) {
  * 
  * $news: news to display
  */
-function get_subtitle($news) {
+function epfl_news_get_subtitle($news) {
     $subtitle = strip_tags($news->subtitle);
     return $subtitle;
 }
@@ -68,7 +68,7 @@ function get_subtitle($news) {
  * 
  * $news: news to display
  */
-function get_visual_url($news) {
+function epfl_news_get_visual_url($news) {
     $visual_url = substr($news->visual_url, 0, -11) . '1296x728.jpg';
     return $visual_url;
 }
@@ -78,7 +78,7 @@ function get_visual_url($news) {
  * 
  * $news: news to display
  */
-function get_media_url($news) {
+function epfl_news_get_media_url($news) {
     $slug = str_replace("https://actu.epfl.ch/news/", "", $news->news_url);
     $video_name = "teaser_" . $slug;
           

--- a/shortcodes/epfl_news/view.php
+++ b/shortcodes/epfl_news/view.php
@@ -10,7 +10,7 @@
   $header = false;
   $last   = count($data);
 
-  $url_channel = get_url_channel($data);
+  $url_channel = epfl_news_get_url_channel($data);
  
 ?>
 
@@ -24,12 +24,12 @@
         foreach($data as $news) {
 
           $is_first_event    = ($count==1);
-          $image_description = get_image_description($news);
-          $category          = get_label_category($news);
-          $publish_date      = get_publish_date($news);
-          $subtitle          = get_subtitle($news);
-          $visual_url        = get_visual_url($news);
-          $media_url         = get_media_url($news);
+          $image_description = epfl_news_get_image_description($news);
+          $category          = epfl_news_get_label_category($news);
+          $publish_date      = epfl_news_get_publish_date($news);
+          $subtitle          = epfl_news_get_subtitle($news);
+          $visual_url        = epfl_news_get_visual_url($news);
+          $media_url         = epfl_news_get_media_url($news);
           
           if ($template == 2 and $count != 1 and $header == false) {
 

--- a/shortcodes/epfl_news/view.php
+++ b/shortcodes/epfl_news/view.php
@@ -64,12 +64,14 @@
   elseif ("3" == $template): // TEMPLATE WWW WITH 1 NEWS
 ?>
 
-        <div class="fullwidth-teaser fullwidth-teaser-horizontal">
+      <div class="fullwidth-teaser fullwidth-teaser-horizontal">
         <?php if ($media_url): ?>
-          <video style="right: 0; bottom: 0; min-width: 100%; min-height: 100%;" autoplay muted loop>
-            <source src="<?php echo $media_url; ?>" type="video/mp4">
-              Your browser does not support HTML5 video.
-          </video>
+          <div class="embed-responsive embed-responsive-16by9">
+            <video autoplay muted loop>
+              <source class="embed-responsive-item" src="<?php echo $media_url; ?>" type="video/mp4">
+                Your browser does not support HTML5 video.
+            </video>
+          </div>
         <?php else: ?>
           <picture>
             <img src="<?php echo $visual_url ?>" aria-labelledby="background-label" alt="<?php echo $image_description ?>"/>
@@ -105,10 +107,12 @@
 
         <div class="fullwidth-teaser fullwidth-teaser-horizontal">
         <?php if ($media_url): ?>
-          <video style="right: 0; bottom: 0; min-width: 100%; min-height: 100%;" autoplay muted loop>
-            <source src="<?php echo $media_url; ?>" type="video/mp4">
-              Your browser does not support HTML5 video.
-          </video>
+          <div class="embed-responsive embed-responsive-16by9">
+            <video autoplay muted loop>
+              <source class="embed-responsive-item" src="<?php echo $media_url; ?>" type="video/mp4">
+                Your browser does not support HTML5 video.
+            </video>
+          </div>
         <?php else: ?>
           <picture>
             <img src="<?php echo $visual_url ?>" aria-labelledby="background-label" alt="<?php echo $image_description ?>"/>

--- a/shortcodes/epfl_news/view.php
+++ b/shortcodes/epfl_news/view.php
@@ -29,7 +29,8 @@
           $publish_date      = epfl_news_get_publish_date($news);
           $subtitle          = epfl_news_get_subtitle($news);
           $visual_url        = epfl_news_get_visual_url($news);
-          $media_url         = epfl_news_get_media_url($news);
+          $video_name        = "teaser_" . str_replace("https://actu.epfl.ch/news/", "", $news->news_url);
+          $media_url         = get_attachment_url_by_slug($video_name);
           
           if ($template == 2 and $count != 1 and $header == false) {
 
@@ -103,7 +104,7 @@
 <?php 
   elseif ("2" == $template): // TEMPLATE WWW WITH 3 NEWS
 ?>
-<?php if (true === $is_first_event): ?>
+<?php if ($is_first_event): ?>
 
         <div class="fullwidth-teaser fullwidth-teaser-horizontal">
         <?php if ($media_url): ?>

--- a/shortcodes/epfl_news/view.php
+++ b/shortcodes/epfl_news/view.php
@@ -66,7 +66,7 @@
 
         <div class="fullwidth-teaser fullwidth-teaser-horizontal">
         <?php if ($media_url): ?>
-          <video style=" right: 0; bottom: 0; min-width: 100%; min-height: 100%;" autoplay muted loop id="myVideo">
+          <video style="right: 0; bottom: 0; min-width: 100%; min-height: 100%;" autoplay muted loop>
             <source src="<?php echo $media_url; ?>" type="video/mp4">
               Your browser does not support HTML5 video.
           </video>
@@ -104,9 +104,16 @@
 <?php if (true === $is_first_event): ?>
 
         <div class="fullwidth-teaser fullwidth-teaser-horizontal">
+        <?php if ($media_url): ?>
+          <video style="right: 0; bottom: 0; min-width: 100%; min-height: 100%;" autoplay muted loop>
+            <source src="<?php echo $media_url; ?>" type="video/mp4">
+              Your browser does not support HTML5 video.
+          </video>
+        <?php else: ?>
           <picture>
             <img src="<?php echo $visual_url ?>" aria-labelledby="background-label" alt="<?php echo $image_description ?>"/>
           </picture>
+        <?php endif ?>
           <div class="fullwidth-teaser-text">
             <div class="fullwidth-teaser-header">
               <div class="fullwidth-teaser-title">

--- a/shortcodes/epfl_news/view.php
+++ b/shortcodes/epfl_news/view.php
@@ -1,18 +1,17 @@
 <?php
-  $template = get_query_var('epfl_news_template');
+
+  require_once('utils.php');
+
+  $template              = get_query_var('epfl_news_template');
   $display_all_news_link = get_query_var('epfl_news_all_news_link');
-  
-  $data = get_query_var('epfl_news_data');
+  $data                  = get_query_var('epfl_news_data');
 
-  $count = 1;
+  $count  = 1;
   $header = false;
-  $last = count($data);
+  $last   = count($data);
 
-  $url_channel = "";
-  if (count($data) > 0) {
-    $channel = $data[0]->channel->name;
-    $url_channel = "https://actu.epfl.ch/search/" . $channel;
-  }
+  $url_channel = get_url_channel($data);
+ 
 ?>
 
 <?php if ("1" == $template): ?>
@@ -24,26 +23,14 @@
       <?php
         foreach($data as $news) {
 
-          $is_first_event = ($count==1);
-
-          if (get_locale() == 'fr_FR') {
-            $image_description = $news->fr_description;
-          } else {
-            $image_description = $news->en_description;
-          }
-
-          if (get_locale() == 'fr_FR') {
-            $category = $news->category->fr_label;
-          } else {
-            $category = $news->category->en_label;
-          }
-
-          $publish_date = new DateTime($news->publish_date);
-          $publish_date = $publish_date->format('d.m.y');
-          $subtitle = strip_tags($news->subtitle);
-
-          $visual_url = substr($news->visual_url, 0, -11) . '1296x728.jpg';
-
+          $is_first_event    = ($count==1);
+          $image_description = get_image_description($news);
+          $category          = get_label_category($news);
+          $publish_date      = get_publish_date($news);
+          $subtitle          = get_subtitle($news);
+          $visual_url        = get_visual_url($news);
+          $media_url         = get_media_url($news);
+          
           if ($template == 2 and $count != 1 and $header == false) {
 
             $header = true;
@@ -78,9 +65,16 @@
 ?>
 
         <div class="fullwidth-teaser fullwidth-teaser-horizontal">
+        <?php if ($media_url): ?>
+          <video style=" right: 0; bottom: 0; min-width: 100%; min-height: 100%;" autoplay muted loop id="myVideo">
+            <source src="<?php echo $media_url; ?>" type="video/mp4">
+              Your browser does not support HTML5 video.
+          </video>
+        <?php else: ?>
           <picture>
             <img src="<?php echo $visual_url ?>" aria-labelledby="background-label" alt="<?php echo $image_description ?>"/>
           </picture>
+        <?php endif ?>
           <div class="fullwidth-teaser-text">
             <div class="fullwidth-teaser-header">
               <div class="fullwidth-teaser-title">


### PR DESCRIPTION
Pour le shortcode epfl-news.
Si pour une news ayant pour slug <slug>, il existe un fichier .mp4 ayant pour nom teaser_<slug>.mp4 alors cette video sera affiché à la place du visual de la news pour les templates de homepage (id=2 et id=3) 
