### PR TITLE
Fix escape html

### DIFF
--- a/shortcodes/epfl_card/view.php
+++ b/shortcodes/epfl_card/view.php
@@ -5,14 +5,14 @@
     $image = get_query_var('epfl_card_image');
 ?>
 
-<a href="<?php echo $link; ?>" class="card link-trapeze-horizontal">
+<a href="<?php echo esc_url($link) ?>" class="card link-trapeze-horizontal">
   <?php if ($image): ?> 
   <picture class="card-img-top">
-    <img src="<?php echo $image; ?>" class="img-fluid" title="<?php echo $title; ?>" alt="<?php echo $title; ?>" />
+    <img src="<?php echo esc_url($image) ?>" class="img-fluid" title="<?php echo esc_attr($title) ?>" alt="<?php echo esc_attr($title) ?>" />
   </picture>
   <?php endif ?>
   <div class="card-body">
-    <h3 class="card-title"><?php echo $title; ?></h3>
-    <p><?php echo $text; ?></p>
+    <h3 class="card-title"><?php echo esc_html($title) ?></h3>
+    <p><?php echo esc_html($text) ?></p>
   </div>
 </a>

--- a/shortcodes/epfl_cover/view.php
+++ b/shortcodes/epfl_cover/view.php
@@ -6,7 +6,7 @@
 <div class="container">
   <figure class="cover">
     <picture>
-      <img src="<?php echo $image; ?>" class="img-fluid" alt="<?php echo $description; ?>">
+      <img src="<?php echo esc_url($image) ?>" class="img-fluid" alt="<?php echo esc_attr($description) ?>">
     </picture>
     <figcaption>
       <button
@@ -14,12 +14,12 @@
         type="button"
         class="btn-circle"
         data-toggle="popover"
-        data-content="<?php echo $description; ?>"
+        data-content="<?php echo esc_attr($description) ?>"
       >
         <svg class="icon" aria-hidden="true"><use xlink:href="#icon-info"></use></svg>
         <svg class="icon icon-rotate-90" aria-hidden="true"><use xlink:href="#icon-chevron-right"></use></svg>
       </button>
-      <p class="sr-only"><?php echo $description; ?></p>
+      <p class="sr-only"><?php echo esc_html($description) ?></p>
       </figcaption>
   </figure>
 </div>

--- a/shortcodes/epfl_links_group/view.php
+++ b/shortcodes/epfl_links_group/view.php
@@ -7,9 +7,9 @@
 <div class="links-group <?php if ($is_links_teaser):?>links-group-teaser<?php endif; ?>">
   <h5 id="links-group-title">
     <?php if($is_links_teaser): ?>
-    <a class="link-pretty" href="<?php echo $main_url; ?>"><?php echo $title; ?></a>
+    <a class="link-pretty" href="<?php echo esc_url($main_url) ?>"><?php echo esc_html($title) ?></a>
     <?php else: ?>
-    <?php echo $title; ?>
+    <?php echo esc_html($title) ?>
     <?php endif; ?>
   </h5>
   <nav
@@ -18,7 +18,7 @@
     aria-labelledby="links-group-title"
   >
   <?php foreach($links as $link): ?>
-    <a class="nav-link link-pretty" href="<?php echo $link['url']; ?>"><?php echo $link['label']; ?></a>
+    <a class="nav-link link-pretty" href="<?php echo esc_url($link['url']) ?>"><?php echo esc_html($link['label']) ?></a>
   <?php endforeach ?>
   </nav>
 </div>

--- a/shortcodes/epfl_memento/controller.php
+++ b/shortcodes/epfl_memento/controller.php
@@ -7,7 +7,6 @@
 add_action('epfl_event_action', 'renderMemento', 1, 3);
 
 function renderMemento($events, $template, $memento) {
-  ob_start();
 
   if (is_admin()) {
 
@@ -24,5 +23,4 @@ function renderMemento($events, $template, $memento) {
     get_template_part('shortcodes/epfl_memento/view');  
     
   }
-  return ob_end_flush();
 }

--- a/shortcodes/epfl_memento/templates/card-img-top.php
+++ b/shortcodes/epfl_memento/templates/card-img-top.php
@@ -10,5 +10,5 @@ if (!$data->visual_url) return '';
 ?>
 
 <picture class="card-img-top">
-    <img src="<?php echo $visual_url ?>" class="img-fluid" title="<?php echo $data->image_description ?>" alt="<?php echo $data->image_description ?>" />
+    <img src="<?php echo esc_url($visual_url) ?>" class="img-fluid" title="<?php echo esc_attr($data->image_description) ?>" alt="<?php echo esc_attr($data->image_description) ?>" />
 </picture>

--- a/shortcodes/epfl_memento/templates/card-info.php
+++ b/shortcodes/epfl_memento/templates/card-info.php
@@ -5,16 +5,16 @@ $data = get_event();
 
 ?>
 <div class="card-info">
-    <span class="card-info-date"><?php echo $data->start_date ?></span>
+    <span class="card-info-date"><?php echo esc_html($data->start_date) ?></span>
 
     <?php if ($data->start_date == $data->end_date): ?>
     
-        <span><?php echo $data->start_time ?></span>
-        <span><?php echo $data->end_time ?></span>
+        <span><?php echo esc_html($data->start_time) ?></span>
+        <span><?php echo esc_html($data->end_time) ?></span>
         
     <?php else: ?>
     
-        <span><?php echo $data->end_date ?></span>
+        <span><?php echo esc_html($data->end_date) ?></span>
 
     <?php endif ?>
     
@@ -22,14 +22,14 @@ $data = get_event();
         <?php if ($data->place_and_room !== ''): ?>
             <?php esc_html_e('Place and room', 'epfl');?>:
         <?php endif ?> 
-        <b><?php echo $data->place_and_room ?></b>
+        <b><?php echo esc_html($data->place_and_room) ?></b>
         <br>
         
         <?php if (get_locale() == 'fr_FR' && $data->category->fr_label !== ''): ?>
-            Catégorie: <b><?php echo $data->category->fr_label ?></b>
+            Catégorie: <b><?php echo esc_html($data->category->fr_label) ?></b>
         <?php else : ?>
             <?php if ($data->category->en_label !== ''): ?>
-            Category: <b><?php echo $data->category->en_label ?></b>
+            Category: <b><?php echo esc_html($data->category->en_label) ?></b>
             <?php endif ?> 
         <?php endif ?> 
     </p>

--- a/shortcodes/epfl_memento/templates/card-slider-footer.php
+++ b/shortcodes/epfl_memento/templates/card-slider-footer.php
@@ -12,6 +12,6 @@ $memento = get_query_var('epfl_memento_name');
         </button>
     </div>
 </div>
-<a href="<?php echo "https://memento.epfl.ch/" . $memento . "/?period=30" ?>">
+<a href="<?php echo esc_url("https://memento.epfl.ch/" . $memento . "/?period=30") ?>">
     <?php esc_html_e('Complete agenda of events', 'epfl');?>
 </a>

--- a/shortcodes/epfl_memento/view.php
+++ b/shortcodes/epfl_memento/view.php
@@ -1,7 +1,7 @@
 <?php
   require_once(get_template_directory().'/shortcodes/epfl_memento/utils.php');
   require_once(get_template_directory().'/shortcodes/epfl_memento/data.php');
-  $data = get_query_var('epfl_memento_data');
+  $data     = get_query_var('epfl_memento_data');
   $template = get_query_var('epfl_memento_template');
   $display_first_event = ('1' === $template);
 ?>
@@ -29,11 +29,11 @@
 <?php if (true === $is_first_event && true === $display_first_event): ?>
 
 <div class="card-slider-cell card-slider-cell-lg">
-  <a href="<?php echo $event->event_url ?>" class="card card-gray link-trapeze-horizontal">
+  <a href="<?php echo esc_url($event->event_url) ?>" class="card card-gray link-trapeze-horizontal">
     <div class="card-body">
       <?php get_template_part('shortcodes/epfl_memento/templates/card-img-top');  ?>
-      <h3 class="card-title"><?php echo $event->title ?></h3>
-      <p><?php echo trim_text(strip_tags($event->description), 225) ?></p>
+      <h3 class="card-title"><?php echo esc_html($event->title) ?></h3>
+      <p><?php echo esc_html(trim_text(strip_tags($event->description), 225)) ?></p>
       <?php get_template_part('shortcodes/epfl_memento/templates/card-info');  ?>
     </div>
   </a>
@@ -45,11 +45,11 @@
 
   <?php if (true === $is_just_finished): ?>
     <div class="card-slider-cell">
-      <a href="<?php echo $event->event_url ?>" class="card card-gray card-grayscale link-trapeze-horizontal bg-gray-100">
+      <a href="<?php echo esc_url($event->event_url) ?>" class="card card-gray card-grayscale link-trapeze-horizontal bg-gray-100">
         <div class="card-body">
           <?php get_template_part('shortcodes/epfl_memento/templates/card-img-top');  ?>
           <h3 class="card-title"><span class="badge badge-dark badge-sm">Just finished</span>
-            <?php echo $event->title ?>
+            <?php echo esc_html($event->title) ?>
           </h3>
           <?php get_template_part('shortcodes/epfl_memento/templates/card-info');  ?>
         </div>
@@ -63,16 +63,16 @@
     <div class="card-slider-cell">
       <div class="card card-gray">
         <div class="card-body">
-          <a href="<?php echo $event->event_url ?>" class="card-img-top">
+          <a href="<?php echo esc_url($event->event_url) ?>" class="card-img-top">
             <?php get_template_part('shortcodes/epfl_memento/templates/card-img-top');  ?>
           </a>
           <h3 class="card-title">
-            <a href="<?php echo $event->event_url ?>"><?php echo $event->title ?></a>
+            <a href="<?php echo esc_url($event->event_url) ?>"><?php echo esc_html($event->title) ?></a>
           </h3>
           <?php get_template_part('shortcodes/epfl_memento/templates/card-info');  ?>
         </div>
         <div class="card-footer mt-auto">
-          <a href="<?php echo $event->event_url ?>" class="btn btn-primary btn-sm">
+          <a href="<?php echo esc_url($event->event_url) ?>" class="btn btn-primary btn-sm">
             <?php esc_html_e('Learn more & apply', 'epfl');?>
           </a>
         </div>
@@ -83,10 +83,10 @@
   <?php else: ?>
 
     <div class="card-slider-cell">
-      <a href="<?php echo $event->event_url ?>" class="card card-gray link-trapeze-horizontal">
+      <a href="<?php echo esc_url($event->event_url) ?>" class="card card-gray link-trapeze-horizontal">
         <div class="card-body">
           <?php get_template_part('shortcodes/epfl_memento/templates/card-img-top');?>
-          <h3 class="card-title"><?php echo $event->title ?></h3>
+          <h3 class="card-title"><?php echo esc_html($event->title) ?></h3>
           <?php get_template_part('shortcodes/epfl_memento/templates/card-info');?>
         </div>
       </a>

--- a/shortcodes/epfl_news/view.php
+++ b/shortcodes/epfl_news/view.php
@@ -57,18 +57,18 @@
 <?php
   if ("1" == $template): // TEMPLATE LISTING
 ?>
-        <a href="<?php echo $news->news_url ?>" class="list-group-item list-group-teaser link-trapeze-vertical">
+        <a href="<?php echo esc_url($news->news_url) ?>" class="list-group-item list-group-teaser link-trapeze-vertical">
           <div class="list-group-teaser-container">
             <div class="list-group-teaser-thumbnail">
               <picture>
-                <img src="<?php echo $visual_url ?>" class="img-fluid" alt="<?php echo $image_description ?>" >
+                <img src="<?php echo esc_url($visual_url) ?>" class="img-fluid" alt="<?php echo esc_attr($image_description) ?>" >
               </picture>
             </div>
             <div class="list-group-teaser-content">
-              <p class="h5"><?php echo $news->title ?></p>
+              <p class="h5"><?php echo esc_html($news->title) ?></p>
               <p>
-                <time datetime="<?php echo $publish_date ?>"><span class="sr-only">Published:</span><?php echo $publish_date ?></time>
-                <span class="text-muted">— <?php echo $subtitle ?></span>
+                <time datetime="<?php echo esc_attr($publish_date) ?>"><span class="sr-only">Published:</span><?php echo esc_html($publish_date) ?></time>
+                <span class="text-muted">— <?php echo esc_html($subtitle) ?></span>
               </p>
             </div>
           </div>
@@ -79,28 +79,28 @@
 
         <div class="fullwidth-teaser fullwidth-teaser-horizontal">
           <picture>
-            <img src="<?php echo $visual_url ?>" aria-labelledby="background-label" alt="<?php echo $image_description ?>"/>
+            <img src="<?php echo esc_url($visual_url) ?>" aria-labelledby="background-label" alt="<?php echo esc_attr($image_description) ?>"/>
           </picture>
           <div class="fullwidth-teaser-text">
             <div class="fullwidth-teaser-header">
               <div class="fullwidth-teaser-title">
                 <h3><?php echo $news->title ?></h3>
                 <ul class="list-inline mt-2">
-                  <li class="list-inline-item"><?php esc_html_e('News', 'epfl');?></li>
-                  <li class="list-inline-item"><?php echo $category ?></li>
+                  <li class="list-inline-item"><?php esc_html_e('News', 'epfl') ?></li>
+                  <li class="list-inline-item"><?php echo esc_html($category) ?></li>
                 </ul>
               </div>
-              <a href="<?php echo $news->news_url ?>" aria-label="Link to read more of that page" class="btn btn-primary triangle-outer-top-right d-none d-xl-block">
+              <a href="<?php echo esc_url($news->news_url) ?>" aria-label="Link to read more of that page" class="btn btn-primary triangle-outer-top-right d-none d-xl-block">
                 <?php esc_html_e('Read more', 'epfl');?>
                 <span class="sr-only">sur Tech Transfer.</span>
                 <svg class="icon" aria-hidden="true"><use xlink:href="#icon-chevron-right"></use></svg>
               </a>
             </div>
             <div class="fullwidth-teaser-content">
-              <p><?php echo $subtitle ?></p>
+              <p><?php echo esc_html($subtitle) ?></p>
             </div>
             <div class="fullwidth-teaser-footer">
-              <a href="<?php echo $news->news_url ?>" aria-label="Link to read more of that page" class="btn btn-primary btn-block d-xl-none"><?php esc_html_e('Read more', 'epfl');?></a>
+              <a href="<?php echo esc_url($news->news_url) ?>" aria-label="Link to read more of that page" class="btn btn-primary btn-block d-xl-none"><?php esc_html_e('Read more', 'epfl');?></a>
             </div>
           </div>
         </div>
@@ -111,28 +111,28 @@
 
         <div class="fullwidth-teaser fullwidth-teaser-horizontal">
           <picture>
-            <img src="<?php echo $visual_url ?>" aria-labelledby="background-label" alt="<?php echo $image_description ?>"/>
+            <img src="<?php echo esc_url($visual_url) ?>" aria-labelledby="background-label" alt="<?php echo esc_attr($image_description) ?>"/>
           </picture>
           <div class="fullwidth-teaser-text">
             <div class="fullwidth-teaser-header">
               <div class="fullwidth-teaser-title">
-                <h3><?php echo $news->title ?></h3>
+                <h3><?php echo esc_html($news->title) ?></h3>
                 <ul class="list-inline mt-2">
-                  <li class="list-inline-item"><?php esc_html_e('News', 'epfl');?></li>
-                  <li class="list-inline-item"><?php echo $category ?></li>
+                  <li class="list-inline-item"><?php esc_html_e('News', 'epfl') ?></li>
+                  <li class="list-inline-item"><?php echo esc_html($category) ?></li>
                 </ul>
               </div>
-              <a href="<?php echo $news->news_url ?>" aria-label="Link to read more of that page" class="btn btn-primary triangle-outer-top-right d-none d-xl-block">
+              <a href="<?php echo esc_url($news->news_url) ?>" aria-label="Link to read more of that page" class="btn btn-primary triangle-outer-top-right d-none d-xl-block">
                 <?php esc_html_e('Read more', 'epfl');?>
                 <span class="sr-only">sur Tech Transfer.</span>
                 <svg class="icon" aria-hidden="true"><use xlink:href="#icon-chevron-right"></use></svg>
               </a>
             </div>
             <div class="fullwidth-teaser-content">
-              <p><?php echo $subtitle ?></p>
+              <p><?php echo esc_html($subtitle) ?></p>
             </div>
             <div class="fullwidth-teaser-footer">
-              <a href="<?php echo $news->news_url ?>" aria-label="Link to read more of that page" class="btn btn-primary btn-block d-xl-none"><?php esc_html_e('Read more', 'epfl');?></a>
+              <a href="<?php echo esc_url($news->news_url) ?>" aria-label="Link to read more of that page" class="btn btn-primary btn-block d-xl-none"><?php esc_html_e('Read more', 'epfl');?></a>
             </div>
           </div>
         </div>
@@ -140,17 +140,17 @@
   <?php else: ?>
 
         <div class="col-md-6 d-flex">
-          <a href="<?php echo $news->news_url ?>" class="card link-trapeze-horizontal">
+          <a href="<?php echo esc_url($news->news_url) ?>" class="card link-trapeze-horizontal">
             <div class="card-body">
-              <h3 class="card-title"><?php echo $news->title ?></h3>
+              <h3 class="card-title"><?php echo esc_html($news->title) ?></h3>
               <div class="card-info">
                 <span class="card-info-date">
-                  <time datetime="DATETIME HERE"><?php echo $publish_date ?></time>
+                  <time datetime="DATETIME HERE"><?php echo esc_html($publish_date) ?></time>
                 </span>
                 <span><?php esc_html_e('News', 'epfl');?></span>
-                <span><?php echo $category ?></span>
+                <span><?php echo esc_html($category) ?></span>
               </div>
-              <p><?php echo $subtitle ?></p>
+              <p><?php echo esc_html($subtitle) ?></p>
             </div>
           </a>
         </div>

--- a/shortcodes/epfl_scienceqa/controller.php
+++ b/shortcodes/epfl_scienceqa/controller.php
@@ -7,8 +7,6 @@
 add_action('epfl_scienceqa_action', 'renderEpflScienceQA', 1, 1);
 
 function renderEpflScienceQA($item) {
-  ob_start();
-
   if (is_admin()) {
 
     // render placeholder for backend editor
@@ -21,5 +19,4 @@ function renderEpflScienceQA($item) {
     get_template_part('shortcodes/epfl_scienceqa/view');  
   
   }
-  return ob_end_flush();
 }

--- a/shortcodes/epfl_scienceqa/view.php
+++ b/shortcodes/epfl_scienceqa/view.php
@@ -6,23 +6,22 @@
   <div class="question">
     <div class="question-img">
       <picture>
-        <img src="<?php echo $data->image ?>" class="img-fluid" alt="image">
+        <img src="<?php echo esc_url($data->image) ?>" class="img-fluid" alt="image">
       </picture>
     </div>
     <div class="question-content">
       <h2 class="question-title"><?php esc_html_e('Question de science', 'epfl-shortcodes') ?></h2>
-      <h2 class="question-subtitle mt-3 mb-0"><?php echo $data->question ?></h2>
-      <form action="<?php echo $url_form ?>" method="POST">
+      <h2 class="question-subtitle mt-3 mb-0"><?php echo esc_html($data->question) ?></h2>
+      <form action="<?php echo esc_url($url_form) ?>" method="POST">
         <div class="question-answers mt-4">
-          
           <?php
             $count = 1; 
             foreach($data->answers as $answerId => $answer) { 
           ?>
-            <input type="radio" id="custom-radio<?php echo $count ?>" value="<?php echo $answerId ?>" name="customRadio" class="custom-control-input">
-            <label class="custom-control-label" for="custom-radio<?php echo $count ?>">
+            <input type="radio" id="custom-radio<?php echo esc_attr($count) ?>" value="<?php echo esc_attr($answerId) ?>" name="customRadio" class="custom-control-input">
+            <label class="custom-control-label" for="custom-radio<?php echo esc_attr($count) ?>">
               <span class="custom-control-label-content">
-                <?php echo $answer ?></span>
+                <?php echo esc_html($answer); ?></span>
               <span class="trapeze-horizontal d-none d-lg-block"></span>
               <span class="trapeze-vertical d-lg-none"></span>
             </label>
@@ -30,7 +29,6 @@
               $count++;
             } 
           ?>
-
         </div>
         <input type="submit" class="btn btn-primary mt-4" value="<?php esc_html_e('Voter', 'epfl-shortcodes') ?>">
       </form>

--- a/shortcodes/epfl_scienceqa/view.php
+++ b/shortcodes/epfl_scienceqa/view.php
@@ -21,7 +21,7 @@
             <input type="radio" id="custom-radio<?php echo esc_attr($count) ?>" value="<?php echo esc_attr($answerId) ?>" name="customRadio" class="custom-control-input">
             <label class="custom-control-label" for="custom-radio<?php echo esc_attr($count) ?>">
               <span class="custom-control-label-content">
-                <?php echo esc_html($answer); ?></span>
+                <?php echo esc_html($answer) ?></span>
               <span class="trapeze-horizontal d-none d-lg-block"></span>
               <span class="trapeze-vertical d-lg-none"></span>
             </label>

--- a/shortcodes/epfl_toggle/view.php
+++ b/shortcodes/epfl_toggle/view.php
@@ -18,7 +18,7 @@
   </button>
   <div 
     class="collapse collapse-item collapse-item-desktop <?php if ($value['state'] === 'open'): ?> show <?php endif ?> " 
-    id="<?php echo esc_attr('collapse' . '-' . $key) ?>"
+    id="<?php echo esc_attr('collapse-' . $key) ?>"
   >
     <p><?php echo wp_kses_post(urldecode($value['desc'])) ?></p>
   </div>

--- a/shortcodes/epfl_toggle/view.php
+++ b/shortcodes/epfl_toggle/view.php
@@ -10,16 +10,16 @@
       class="collapse-title collapse-title-desktop collapsed"
       type="button"
       data-toggle="collapse"
-      data-target="<?php echo esc_attr('#collapse-' . $key); ?>"
+      data-target="<?php echo esc_attr('#collapse-' . $key) ?>"
       aria-expanded="false"
-      aria-controls="<?php echo esc_attr('#collapse-' . $key); ?>"
+      aria-controls="<?php echo esc_attr('#collapse-' . $key) ?>"
     >
-    <?php echo esc_html($value['label']); ?>
+    <?php echo esc_html($value['label']) ?>
   </button>
   <div 
-    class="collapse collapse-item collapse-item-desktop <?php if ($value['state'] === 'open'): ?> show <?php endif; ?> " 
+    class="collapse collapse-item collapse-item-desktop <?php if ($value['state'] === 'open'): ?> show <?php endif ?> " 
     id="<?php echo esc_attr('collapse' . '-' . $key) ?>"
   >
-    <p><?php echo wp_kses_post(urldecode($value['desc'])); ?></p>
+    <p><?php echo wp_kses_post(urldecode($value['desc'])) ?></p>
   </div>
 <?php endforeach; ?>

--- a/shortcodes/epfl_toggle/view.php
+++ b/shortcodes/epfl_toggle/view.php
@@ -10,16 +10,16 @@
       class="collapse-title collapse-title-desktop collapsed"
       type="button"
       data-toggle="collapse"
-      data-target="<?php echo '#collapse-' . $key ?>"
+      data-target="<?php echo esc_attr('#collapse-' . $key); ?>"
       aria-expanded="false"
-      aria-controls="<?php echo '#collapse-' . $key ?>"
+      aria-controls="<?php echo esc_attr('#collapse-' . $key); ?>"
     >
-    <?php echo $value['label']; ?>
+    <?php echo esc_html($value['label']); ?>
   </button>
   <div 
     class="collapse collapse-item collapse-item-desktop <?php if ($value['state'] === 'open'): ?> show <?php endif; ?> " 
-    id="<?php echo 'collapse' . '-' . $key ?>"
+    id="<?php echo esc_attr('collapse' . '-' . $key) ?>"
   >
-    <p><?php echo urldecode($value['desc']); ?></p>
+    <p><?php echo wp_kses_post(urldecode($value['desc'])); ?></p>
   </div>
 <?php endforeach; ?>

--- a/shortcodes/epfl_video/view.php
+++ b/shortcodes/epfl_video/view.php
@@ -6,6 +6,6 @@
 
 <div class="container">
   <div class="embed-responsive embed-responsive-16by9">
-    <iframe src="<?php echo $url ?>" width="<?php echo $width ?>" height="<?php echo $height ?>" webkitallowfullscreen mozallowfullscreen allowfullscreen allow="autoplay; encrypted-media" frameborder="0" class="embed-responsive-item"></iframe>
+    <iframe src="<?php echo esc_url($url); ?>" width="<?php echo esc_attr($width); ?>" height="<?php echo esc_attr($height); ?>" webkitallowfullscreen mozallowfullscreen allowfullscreen allow="autoplay; encrypted-media" frameborder="0" class="embed-responsive-item"></iframe>
   </div>
 </div>

--- a/shortcodes/epfl_video/view.php
+++ b/shortcodes/epfl_video/view.php
@@ -6,6 +6,6 @@
 
 <div class="container">
   <div class="embed-responsive embed-responsive-16by9">
-    <iframe src="<?php echo esc_url($url); ?>" width="<?php echo esc_attr($width); ?>" height="<?php echo esc_attr($height); ?>" webkitallowfullscreen mozallowfullscreen allowfullscreen allow="autoplay; encrypted-media" frameborder="0" class="embed-responsive-item"></iframe>
+    <iframe src="<?php echo esc_url($url) ?>" width="<?php echo esc_attr($width) ?>" height="<?php echo esc_attr($height) ?>" webkitallowfullscreen mozallowfullscreen allowfullscreen allow="autoplay; encrypted-media" frameborder="0" class="embed-responsive-item"></iframe>
   </div>
 </div>


### PR DESCRIPTION
Echappe les variables utilisées dans les templates

Utilisation de : 
- esc_url() pour les urls
- esc_attr() pour les attributs
- esc_html() pour les variables placées dans une balise html
- wp_kses_post() pour les variables placées dans une balise html qui contiennent des balises HTML à conserver (strong, etc)

Suppression de "scories" de ob_start(); ob_end_flush();