### PR TITLE
clean width and heigt parameters

### DIFF
--- a/shortcodes/epfl_video/controller.php
+++ b/shortcodes/epfl_video/controller.php
@@ -5,9 +5,9 @@
  * 4rth argument is number of arguments the function can accept
  **/
 
-add_action('epfl_video_action', 'renderVideo', 10, 3);
+add_action('epfl_video_action', 'renderVideo', 10, 1);
 
-function renderVideo ($url, $width, $height) {
+function renderVideo ($url) {
 
   if (is_admin()) {
 
@@ -18,8 +18,6 @@ function renderVideo ($url, $width, $height) {
   } else {
     
     set_query_var('epfl_video_url', $url);
-    set_query_var('epfl_video_width', $width);
-    set_query_var('epfl_video_height', $height);
     get_template_part('shortcodes/epfl_video/view');
   }
 }

--- a/shortcodes/epfl_video/view.php
+++ b/shortcodes/epfl_video/view.php
@@ -1,11 +1,9 @@
 <?php
-  $url    = get_query_var('epfl_video_url');
-  $width  = get_query_var('epfl_video_width');
-  $height = get_query_var('epfl_video_height');
+  $url = get_query_var('epfl_video_url');
 ?>
 
 <div class="container">
   <div class="embed-responsive embed-responsive-16by9">
-    <iframe src="<?php echo esc_url($url) ?>" width="<?php echo esc_attr($width) ?>" height="<?php echo esc_attr($height) ?>" webkitallowfullscreen mozallowfullscreen allowfullscreen allow="autoplay; encrypted-media" frameborder="0" class="embed-responsive-item"></iframe>
+    <iframe src="<?php echo esc_url($url) ?>" webkitallowfullscreen mozallowfullscreen allowfullscreen allow="autoplay; encrypted-media" frameborder="0" class="embed-responsive-item"></iframe>
   </div>
 </div>


### PR DESCRIPTION
- supprimer les paramètres width et height du shortcode epfl-video
- cela a été fait pour le shortcode epfl-video 2010 mais pas pour celui présent dans le plugin epfl