### PR TITLE
Ensure that toggle ID is unique (or seriously reduce collision risk)

### DIFF
--- a/shortcodes/epfl_toggle/view.php
+++ b/shortcodes/epfl_toggle/view.php
@@ -2,21 +2,23 @@
   $title   = get_query_var('epfl_toggle_title');
   $state   = get_query_var('epfl_toggle_state');
   $content = get_query_var('epfl_toggle_content');
+
+  $toggle_id = md5($content . rand());
 ?>
 
 <button
       class="collapse-title collapse-title-desktop <?php if ($state === 'close'): ?> collapsed <?php endif ?>"
       type="button"
       data-toggle="collapse"
-      data-target="<?php echo esc_attr('#collapse-' . $title) ?>"
+      data-target="<?php echo esc_attr('#collapse-' . $toggle_id) ?>"
       aria-expanded="false"
-      aria-controls="<?php echo esc_attr('#collapse-' . $title) ?>"
+      aria-controls="<?php echo esc_attr('#collapse-' . $toggle_id) ?>"
     >
     <?php echo esc_html($title) ?>
   </button>
   <div 
     class="collapse collapse-item collapse-item-desktop <?php if ($state === 'open'): ?> show <?php endif ?> " 
-    id="<?php echo esc_attr('collapse-' . $title) ?>"
+    id="<?php echo esc_attr('collapse-' . $toggle_id) ?>"
   >
     <p><?php echo wp_kses_post(do_shortcode( $content )) ?></p>
   </div>


### PR DESCRIPTION
Jusqu'à présent, uniquement le titre d'un toggle était utilisé comme identifiant donc si on avait 2x le même titre, l'affichage ne se faisait pas correctement. Cette PR résout le problème.

Et j'ai remarqué qu'il y avait un petit bug dans l'affichage si on mettait plusieurs Toggle à la suite. Le premier, WordPress l'ajoute dans un `<p>`, ce qui fait qu'il y a une marge qui est ajoutée automatiquement à la fin... mais pour les Toggles suivants, pas de problème.