### PR TITLE
use crop_large instead crop (too short)

### DIFF
--- a/shortcodes/custom_teasers/view.php
+++ b/shortcodes/custom_teasers/view.php
@@ -29,7 +29,7 @@ if ($data['graybackground'] === 'true') $greyClasses = 'bg-gray-100 py-4 mt-4';
           <picture>
           <?php echo wp_get_attachment_image(
             $data['image'.$i],
-            'thumbnail_16_9_crop', // see functions.php
+            'thumbnail_16_9_large', // see functions.php
             '',
             [
               'class' => 'img-fluid',

--- a/shortcodes/epfl_card/view.php
+++ b/shortcodes/epfl_card/view.php
@@ -34,7 +34,7 @@
         <picture>
         <?php echo wp_get_attachment_image(
           $image_id,
-          'thumbnail_16_9_crop', // see functions.php
+          'thumbnail_16_9_large', // see functions.php
           '',
           [
             'class' => 'img-fluid',

--- a/shortcodes/epfl_cover/view.php
+++ b/shortcodes/epfl_cover/view.php
@@ -8,7 +8,7 @@
     <picture>
       <?php echo wp_get_attachment_image(
         $image,
-        'thumbnail_16_9_crop', // see functions.php
+        'thumbnail_16_9_large', // see functions.php
         '',
         [
           'class' => 'img-fluid',

--- a/shortcodes/page_teaser/view.php
+++ b/shortcodes/page_teaser/view.php
@@ -15,7 +15,7 @@ $gray = $data['gray'];
           <?php
           $page_url = get_permalink($page);
             card_img_top(
-              get_the_post_thumbnail($page, 'thumbnail_16_9_crop', ['class' => 'img-fluid']),
+              get_the_post_thumbnail($page, 'thumbnail_16_9_large', ['class' => 'img-fluid']),
               $page_url
             );
           ?>

--- a/shortcodes/post_teaser/view.php
+++ b/shortcodes/post_teaser/view.php
@@ -14,7 +14,7 @@ if (isset($data['gray'])) $postCount = $postCount - 1;
         <a href="<?php echo $post_url ?>" class="card link-trapeze-horizontal">
           <?php
             card_img_top(
-              get_the_post_thumbnail($post, 'thumbnail_16_9_crop', ['class' => 'img-fluid']),
+              get_the_post_thumbnail($post, 'thumbnail_16_9_large', ['class' => 'img-fluid']),
               $post_url,
               false
             );

--- a/shortcodes/schools/view.php
+++ b/shortcodes/schools/view.php
@@ -11,7 +11,7 @@
           <div class="col-sm-4">
             <a href="<?php echo $data['link'.$i]; ?>" class="card card-overlay link-trapeze-horizontal">
               <picture class="card-img">
-                <?php echo wp_get_attachment_image($data['image'.$i], 'thumbnail_16_9_crop', '', ['class' => 'img-fluid']) ?>
+                <?php echo wp_get_attachment_image($data['image'.$i], 'thumbnail_16_9_large', '', ['class' => 'img-fluid']) ?>
               </picture>
               <div class="card-img-overlay">
                 <h3 class="h4 card-title">


### PR DESCRIPTION
Les images dans plusieurs shortcodes étaient croppées avec une résolution de l'image trop petite (384, 216).  Avec ces PR les images croppées auront les dimensions (1920, 1080).
