### PR TITLE
Shortcode epfl_links_group: Add margin

### DIFF
--- a/shortcodes/epfl_links_group/view.php
+++ b/shortcodes/epfl_links_group/view.php
@@ -4,21 +4,24 @@
     $title    = get_query_var('epfl_links_group_title');
     $is_links_teaser = ("" !== $main_url);
 ?>
-<div class="links-group <?php if ($is_links_teaser):?>links-group-teaser<?php endif; ?>">
-  <h5 id="links-group-title">
-    <?php if($is_links_teaser): ?>
-    <a class="link-pretty" href="<?php echo esc_url($main_url) ?>"><?php echo esc_html($title) ?></a>
-    <?php else: ?>
-    <?php echo esc_html($title) ?>
-    <?php endif; ?>
-  </h5>
-  <nav
-    class="nav flex-column flex-wrap align-items-start"
-    role="navigation"
-    aria-labelledby="links-group-title"
-  >
-  <?php foreach($links as $link): ?>
-    <a class="nav-link link-pretty" href="<?php echo esc_url($link['url']) ?>"><?php echo esc_html($link['label']) ?></a>
-  <?php endforeach ?>
-  </nav>
+<div class="container-grid my-3">
+  <div class="links-group <?php if ($is_links_teaser):?>links-group-teaser<?php endif; ?>">
+
+    <h5 id="links-group-title">
+      <?php if($is_links_teaser): ?>
+      <a class="link-pretty" href="<?php echo esc_url($main_url) ?>"><?php echo esc_html($title) ?></a>
+      <?php else: ?>
+      <?php echo esc_html($title) ?>
+      <?php endif; ?>
+    </h5>
+    <nav
+      class="nav flex-column flex-wrap align-items-start"
+      role="navigation"
+      aria-labelledby="links-group-title"
+    >
+    <?php foreach($links as $link): ?>
+      <a class="nav-link link-pretty" href="<?php echo esc_url($link['url']) ?>"><?php echo esc_html($link['label']) ?></a>
+    <?php endforeach ?>
+    </nav>
+  </div>
 </div>

--- a/shortcodes/epfl_links_group/view.php
+++ b/shortcodes/epfl_links_group/view.php
@@ -6,7 +6,6 @@
 ?>
 <div class="container-grid my-3">
   <div class="links-group <?php if ($is_links_teaser):?>links-group-teaser<?php endif; ?>">
-
     <h5 id="links-group-title">
       <?php if($is_links_teaser): ?>
       <a class="link-pretty" href="<?php echo esc_url($main_url) ?>"><?php echo esc_html($title) ?></a>


### PR DESCRIPTION
Pour le shortcode epfl_links_group, on ajoute une marge afin que par exemple, lorsque l'on ajoute 2 shortcodes epfl_links_group, les 2 éléments ne soient pas "collés"
