### PR TITLE
Fix php notices

### DIFF
--- a/menus/custom-nav-walker.php
+++ b/menus/custom-nav-walker.php
@@ -166,11 +166,13 @@ class Custom_Nav_Walker extends Walker_Nav_Menu
 		 */
 		$title = apply_filters( 'nav_menu_item_title', $title, $item, $args, $depth );
 
-		$item_output = $args->before;
+		$item_output = property_exists($args, 'before')?$args->before:'';
 		$item_output .= '<a'. $attributes .'>';
-		$item_output .= $args->link_before . $title . $args->link_after;
+		$item_output .= (property_exists($args, 'link_before')?$args->link_before:'') .
+		                $title .
+		                (property_exists($args, 'link_after')?$args->link_after:'');
 		$item_output .= '</a>';
-		$item_output .= $args->after;
+		$item_output .= property_exists($args, 'after')?$args->after:'';
 		if(is_array($item->classes) && in_array('menu-item-has-children', $item->classes)) {
 			$item_output .= '
 						<a href="#" role="button" aria-hidden="true" class="nav-arrow">

--- a/shortcodes/custom_teasers/shortcake.php
+++ b/shortcodes/custom_teasers/shortcake.php
@@ -9,7 +9,7 @@ function custom_teasers() {
 
   $fields = [
 		array(
-					'label'    => '<hr><h2>Section title '.$i.'</h2> '.$i,
+					'label'    => '<hr><h2>Section title</h2>',
 					'attr'     => 'titlesection',
 					'type'     => 'text'
 				),

--- a/shortcodes/epfl_publication/renderers/publications.php
+++ b/shortcodes/epfl_publication/renderers/publications.php
@@ -49,14 +49,11 @@ abstract Class InfosciencePublication2018Render {
     protected static $format="short";
 
     protected static function get_content($publication, $format, $summary) {
-        $html_rendered .= PublicationDateInfoscienceField2018Render::render($publication, static::$format);
-        return $html_rendered;
+        return PublicationDateInfoscienceField2018Render::render($publication, static::$format);
     }
     
     public static function render($publication, $format, $summary) {
-        $html_rendered = '';
-
-        $html_rendered .= AuthorInfoscienceField2018Render::render($publication, $format, NULL, 'author');
+        $html_rendered = AuthorInfoscienceField2018Render::render($publication, $format, NULL, 'author');
 
         if ($summary) {
             $html_rendered .= SummaryInfoscienceField2018Render::render($publication, self::$format, false);

--- a/shortcodes/page_teaser/shortcake.php
+++ b/shortcodes/page_teaser/shortcake.php
@@ -13,7 +13,7 @@ function page_teaser() {
       'description' => esc_html__('Change the background to gray', 'epfl')
     ]);
 
-  for($i; $i < 3; $i++) {
+  for($i=0; $i < 3; $i++) {
     array_push($fields, array(
       'label'    => esc_html__( 'Select page' , 'epfl'),
 			'attr'     => 'page'.$i,

--- a/shortcodes/post_teaser/shortcake.php
+++ b/shortcodes/post_teaser/shortcake.php
@@ -13,7 +13,7 @@ function post_teaser() {
       'description' => esc_html__('Change the background to gray', 'epfl')
     ]);
 
-  for($i; $i < 3; $i++) {
+  for($i=0; $i < 3; $i++) {
     array_push($fields, array(
       'label'    => esc_html__( 'Select post' , 'epfl'),
 			'attr'     => 'post'.$i,

--- a/sidebar.php
+++ b/sidebar.php
@@ -17,7 +17,7 @@ $item = reset(wp_filter_object_list( $items, ['object_id' => $post->ID]));
 
 // to display correctly the menu on level 1 pages, we need to add '.current-menu-parent' to the wrapper
 $classes = '';
-if ( $item->menu_item_parent == 0 || $item === false ) $classes = 'current-menu-parent';
+if ($item === false || $item->menu_item_parent == 0 ) $classes = 'current-menu-parent';
 ?>
 <div class="overlay"></div>
 <nav class="nav-main">

--- a/template-parts/breadcrumb.php
+++ b/template-parts/breadcrumb.php
@@ -29,8 +29,11 @@ if ($currentTemplate == 'page-homepage.php') {
   <?php
     // Breadcrumb
     $items = array();
-    foreach (wp_get_nav_menu_items(get_current_menu_slug()) as $item) {
-        $items[(int) $item->db_id] = $item;
+    if(($menu_items = wp_get_nav_menu_items(get_current_menu_slug()))!==false)
+    {
+        foreach ($menu_items as $item) {
+            $items[(int) $item->db_id] = $item;
+        }
     }
 
     $item = $items ? reset(wp_filter_object_list( $items, ['object_id' => $post->ID])) : false;


### PR DESCRIPTION
1. Correction de quelques PHP notices qui me pourrissaient les log quand debug activé.
1. Gestion de l'absence de breadcrumb (cas de figure rencontré lorsque l'on créé un site WWW2018 from scratch).