### PR TITLE
Active the "don't track" option for Twitter

### DIFF
--- a/shortcodes/epfl_social_feed/twitter_view.php
+++ b/shortcodes/epfl_social_feed/twitter_view.php
@@ -15,6 +15,7 @@
         <?php endif ?>
         data-chrome="nofooter"
         data-height="<?php esc_html_e($height) ?>"
+        data-dnt="true"
         href="<?php echo esc_url($twitter_url) ?>">
       </a>
       <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>      


### PR DESCRIPTION
Dans certains cas, l'affichage de Twitter ne se fait pas. Si ce n'est une protection de twitter lorsqu'une url est trop demandée, j'ai quelques raisons de penser que le probème provient du tracking activé de twitter. En effet, il s'avère parfois que de désactiver l'option "Don't track" dans firefox raffiche la timeline Twitter. Cette PR pourrait donc résoudre ceci.

voir https://developer.twitter.com/en/docs/twitter-for-websites/embedded-tweets/guides/embedded-tweet-parameter-reference.html -> dnt