### PR TITLE
Ability to override root menus with personalized entries

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -10,6 +10,9 @@
 global $EPFL_MENU_LOCATION;
 $EPFL_MENU_LOCATION = 'top';
 
+global $EPFL_MENU_OVERRIDE_LOCATION;
+$EPFL_MENU_OVERRIDE_LOCATION = '_top_override';
+
 global $EPFL_FOOTER_MENU_LOCATION;
 $EPFL_FOOTER_MENU_LOCATION = 'footer_nav';
 
@@ -50,9 +53,11 @@ if ( ! function_exists( 'epfl_setup' ) ) :
 
 		// This theme uses wp_nav_menu() in one location.
 		global $EPFL_MENU_LOCATION;
+		global $EPFL_MENU_OVERRIDE_LOCATION;
 		global $EPFL_FOOTER_MENU_LOCATION;
 		$nav_menus_args = [];
 		$nav_menus_args[$EPFL_MENU_LOCATION] = esc_html__( 'Primary', 'epfl' );
+        $nav_menus_args[$EPFL_MENU_OVERRIDE_LOCATION] = esc_html__( 'Top Menu Override', 'epfl' );
 		$nav_menus_args[$EPFL_FOOTER_MENU_LOCATION] = esc_html__( 'Footer', 'epfl' );
 		register_nav_menus($nav_menus_args);
 

--- a/functions.php
+++ b/functions.php
@@ -57,7 +57,9 @@ if ( ! function_exists( 'epfl_setup' ) ) :
 		global $EPFL_FOOTER_MENU_LOCATION;
 		$nav_menus_args = [];
 		$nav_menus_args[$EPFL_MENU_LOCATION] = esc_html__( 'Primary', 'epfl' );
-        $nav_menus_args[$EPFL_MENU_OVERRIDE_LOCATION] = esc_html__( 'Top Menu Override', 'epfl' );
+        if (root_menu_overrides_enabled()) {
+            $nav_menus_args[$EPFL_MENU_OVERRIDE_LOCATION] = esc_html__( 'Top Menu Override', 'epfl' );
+        }
 		$nav_menus_args[$EPFL_FOOTER_MENU_LOCATION] = esc_html__( 'Footer', 'epfl' );
 		register_nav_menus($nav_menus_args);
 
@@ -318,6 +320,15 @@ function get_current_menu_slug() {
   $menu_locations = get_nav_menu_locations();
   $menu_term = get_term($menu_locations[$EPFL_MENU_LOCATION], 'nav_menu');
 	return $menu_term;
+}
+
+/**
+ * @return boolean True iff the site editors and administrator may
+ *                 override the entries in the root menu with their
+ *                 own pages, posts or links
+ */
+function root_menu_overrides_enabled () {
+    return (bool) get_site_option('epfl2018-root-menu-overrides-enabled');
 }
 
 /**

--- a/functions.php
+++ b/functions.php
@@ -309,17 +309,19 @@ add_filter("get_archives_link", "get_archives_link_mod");
 add_post_type_support( 'page', 'excerpt' );
 
 /**
- * get_current_menu_slug
- * returns the slug of the current menu occupying the primary theme_location
- * also works when using polylang
+ * Returns the WP_Term object to use for the menu (Polylang-compatible)
  *
- * @return string
+ * @param $slug    The (language-neutral form of the) slug to retrieve;
+ *                 by default, use the main menu (i.e. "top")
+ * @return WP_Term The WP_Term for that menu in the current language
  */
-function get_current_menu_slug() {
+function get_current_menu_slug ($slug = NULL) {
+  if (! $slug) {
     global $EPFL_MENU_LOCATION;
+    $slug = $EPFL_MENU_LOCATION;
+  }
   $menu_locations = get_nav_menu_locations();
-  $menu_term = get_term($menu_locations[$EPFL_MENU_LOCATION], 'nav_menu');
-	return $menu_term;
+  return get_term($menu_locations[$slug], 'nav_menu');
 }
 
 /**

--- a/header.php
+++ b/header.php
@@ -9,6 +9,37 @@
  * @package epfl
  */
 
+
+/**
+ * A subclass of @link Walker_Nav_Menu to customize the root menu
+ *
+ *
+ */
+class EPFL_Theme2018_Root_Menu_Walker extends Walker_Nav_Menu {
+    function start_el (&$output, $item, $depth = 0, $args = array(), $id = 0) {
+        if ($surrogate_menu = $this->_get_surrogate_menu()) {
+            foreach ($surrogate_menu as $surrogate_item) {
+                if ($item->title === $surrogate_item->title) {
+                    $item = $surrogate_item;
+                    break;
+                }
+            }
+        }
+        return parent::start_el($output, $item, $depth, $args, $id);
+    }
+
+    private function _get_surrogate_menu () {
+        require_once(__DIR__ . '/functions.php');
+        if (! root_menu_overrides_enabled()) return false;
+
+        if (! property_exists($this, '_surrogate_menu')) {
+            global $EPFL_MENU_OVERRIDE_LOCATION;
+            $this->_surrogate_menu = wp_get_nav_menu_items(get_current_menu_slug($EPFL_MENU_OVERRIDE_LOCATION));
+        }
+        return $this->_surrogate_menu;
+    }
+}
+
 ?>
 <!doctype html>
 <html <?php language_attributes(); ?>>
@@ -36,7 +67,8 @@
         		    'menu_id'        => $EPFL_MENU_LOCATION.'-menu',
 					'menu_class'=> 'nav-header d-none d-xl-flex',
 					'container' => 'ul',
-					'depth' => 1
+					'depth' => 1,
+					'walker' => new EPFL_Theme2018_Root_Menu_Walker()
 				) );
 			?>
 


### PR DESCRIPTION
* Guarded by option 'epfl2018-root-menu-overrides-enabled'; does nothing unless option is set
* If option is set, a new menu location appears in the theme ('Top Menu Override', translatable like all the others)
* Any menu entry that has the same title as a menu entry at the root of the main menu, replaces it whenever the top navigation bar is rendered.
