### PR TITLE
[WIP] fix image_size with defaut value from memento webservice

### DIFF
--- a/shortcodes/epfl_memento/templates/card-img-top.php
+++ b/shortcodes/epfl_memento/templates/card-img-top.php
@@ -3,7 +3,7 @@
 require_once(get_template_directory().'/shortcodes/epfl_memento/data.php');
 $data = get_event();
 
-$visual_url = substr($data->visual_url, 0, -11) . '448x448.jpg';
+$visual_url = $data->visual_url;
 
 //display nothing if no image available
 if (!$data->visual_url) return '';

--- a/shortcodes/epfl_memento/view.php
+++ b/shortcodes/epfl_memento/view.php
@@ -153,7 +153,7 @@ $count++;
     foreach($data as $event) {
       set_query_var('epfl_event', $event);
       $is_first_event = ($count==1);
-      $visual_url = substr($event->visual_url, 0, -11) . '448x448.jpg';
+      $visual_url = $event->visual_url;
 
 ?>
 


### PR DESCRIPTION
Pour la taille des images provenant de memento, on ne tente plus "d'optimiser" mais on prend les dimensions des images définies dans l'API REST de Memento.
Pourquoi ? Car bientôt, avec l'adaptation de la charte graphique dans memento, on va devoir vivre avec 2 dimensions d'images différents. En effet, selon si l'événement a été publié avant ou après la mise en ligne de la nouvelle charte graphique dans memento, les dimensions des images ne seront pas les mêmes