### PR TITLE
"Phantom" menu entry (for labs at the root)

### DIFF
--- a/header.php
+++ b/header.php
@@ -11,9 +11,10 @@
 
 
 /**
- * A subclass of @link Walker_Nav_Menu to customize the root menu
+ * Substitute locally-defined nav menu items with the same set_title
  *
- *
+ * This lets e.g. school-level sites redirect their "Education", "Research" etc.
+ * pages
  */
 class EPFL_Theme2018_Root_Menu_Walker extends Walker_Nav_Menu {
     function start_el (&$output, $item, $depth = 0, $args = array(), $id = 0) {
@@ -66,7 +67,7 @@ class EPFL_Theme2018_Root_Menu_Walker extends Walker_Nav_Menu {
 	<a class="sr-only" href="#content"><?php esc_html_e( 'Skip to content', 'epfl' ); ?></a>
 
 	<header role="banner" class="header">
-  	
+
   	<div class="site-branding">
   	    <a class="logo" href="<?php echo get_epfl_home_url(); ?>">
   			<img src="<?php bloginfo('template_url'); ?>/assets/svg/epfl-logo.svg" alt="Logo EPFL, École polytechnique fédérale de Lausanne" class="img-fluid">

--- a/header.php
+++ b/header.php
@@ -45,9 +45,8 @@ class EPFL_Theme2018_Root_Menu_Walker extends Walker_Nav_Menu {
 		# as we don't want it to show in top
 		$filtered_elements = array_filter($elements,
 			function ($element) {
-				return (!property_exists($element, 'epfl_has_external_menu_child') ||
-						(property_exists($element, 'epfl_has_external_menu_child') && !$element->epfl_has_external_menu_child)
-					);
+				return (! (property_exists($element, 'epfl_external_menu_children_count') &&
+						$element->epfl_external_menu_children_count));
 				});
 
 		return parent::walk($filtered_elements, $max_depth);

--- a/header.php
+++ b/header.php
@@ -11,10 +11,14 @@
 
 
 /**
- * Substitute locally-defined nav menu items with the same set_title
+ * Custom nav menu walker for the top bar
  *
- * This lets e.g. school-level sites redirect their "Education", "Research" etc.
- * pages
+ * + Remove so-called "phantom" top-level navigation entries such as "Labs",
+ *   that only exist as placeholders
+ *
+ * + Substitute locally-defined nav menu items with the same set_title.
+ *   This lets e.g. school-level sites redirect their "Education", "Research" etc.
+ *   pages
  */
 class EPFL_Theme2018_Root_Menu_Walker extends Walker_Nav_Menu {
     function start_el (&$output, $item, $depth = 0, $args = array(), $id = 0) {

--- a/header.php
+++ b/header.php
@@ -39,6 +39,19 @@ class EPFL_Theme2018_Root_Menu_Walker extends Walker_Nav_Menu {
         }
         return $this->_surrogate_menu;
     }
+
+	public function walk( $elements, $max_depth ) {
+		# filter custom link with an epfl_has_external_menu_child,
+		# as we don't want it to show in top
+		$filtered_elements = array_filter($elements,
+			function ($element) {
+				return (!property_exists($element, 'epfl_has_external_menu_child') ||
+						(property_exists($element, 'epfl_has_external_menu_child') && !$element->epfl_has_external_menu_child)
+					);
+				});
+
+		return parent::walk($filtered_elements, $max_depth);
+	}
 }
 
 ?>

--- a/header.php
+++ b/header.php
@@ -52,21 +52,21 @@ class EPFL_Theme2018_Root_Menu_Walker extends Walker_Nav_Menu {
           $site_url .= '/';
         }
 
-		$filtered_elements = array_filter($elements,
+        $filtered_elements = array_filter($elements,
       		function ($element) use ($elements, $site_url) {
-            if (property_exists($element, 'epfl_external_menu_children_count') &&
-      				$element->epfl_external_menu_children_count == 1) {
-                $other_children_count = count(array_filter($elements,
-                  function($child) use ($element, $site_url) {
-                    return ($child->menu_item_parent == $element->ID &&
-                            $child->epfl_soa != $site_url);
-                  }));
-                  if ($other_children_count === 0) return false;
-            }
-            return true;
-			});
+				if (property_exists($element, 'epfl_external_menu_children_count') &&
+						$element->epfl_external_menu_children_count == 1) {
+					$other_children_count = count(array_filter($elements,
+					function($child) use ($element, $site_url) {
+						return ($child->menu_item_parent == $element->ID &&
+								$child->epfl_soa != $site_url);
+					}));
+					if ($other_children_count === 0) return false;
+				}
+				return true;
+            });
 
-		return parent::walk($filtered_elements, $max_depth);
+      	return parent::walk($filtered_elements, $max_depth);
 	}
 }
 

--- a/header.php
+++ b/header.php
@@ -46,8 +46,8 @@ class EPFL_Theme2018_Root_Menu_Walker extends Walker_Nav_Menu {
 		$filtered_elements = array_filter($elements,
 			function ($element) {
 				return (! (property_exists($element, 'epfl_external_menu_children_count') &&
-						$element->epfl_external_menu_children_count));
-				});
+						$element->epfl_external_menu_children_count == 1));
+			});
 
 		return parent::walk($filtered_elements, $max_depth);
 	}


### PR DESCRIPTION
Labs want to exist at EPFL → Labs → MYLAB. We don't want "Labs" to show up in the top menu.

High-level changes:
* Menu entries that have exactly one ExternalMenuItem as children (and nothing else) are omitted from the top menu

Low-level changes:
* Implement that check in the ->walk() method of our custom menu walker
* [Rely on the epfl plug-in](https://github.com/epfl-idevelop/jahia2wp/pull/906) to tell us how many ExternalMenuItem children there are to any given node