### PR TITLE
Optimize image size for display (srcset)

### DIFF
--- a/wp-theme-2018/functions.php
+++ b/wp-theme-2018/functions.php
@@ -248,8 +248,11 @@ function init_globals() {
  * add a 16/9 thumbnail size with cropping
  * used in card headers
  */
-add_image_size( 'thumbnail_16_9_crop', 384, 216, ['center', 'center'] );
+add_image_size( 'thumbnail_16_9_crop', 384, 216, ['center', 'center'] ); // 20% of full (1920x1080) size
 add_image_size( 'thumbnail_16_9_large', 1920, 1080, ['center', 'center'] );
+add_image_size( 'thumbnail_16_9_large_80p', 1536, 864, ['center', 'center'] ); // 80% of full size
+add_image_size( 'thumbnail_16_9_large_60p', 1152, 648, ['center', 'center'] ); // 60% of full size
+add_image_size( 'thumbnail_16_9_large_40p', 768, 432, ['center', 'center'] ); // 40% of full size
 add_image_size( 'thumbnail_square_crop', 300, 300, ['center', 'center'] );
 
 /**

--- a/wp-theme-2018/shortcodes/custom_teasers/view.php
+++ b/wp-theme-2018/shortcodes/custom_teasers/view.php
@@ -29,7 +29,7 @@ if ($data['graybackground'] === 'true') $greyClasses = 'bg-gray-100 py-4 mt-4';
           <picture>
           <?php echo wp_get_attachment_image(
             $data['image'.$i],
-            'thumbnail_16_9_large', // see functions.php
+            'thumbnail_16_9_crop', // see functions.php
             '',
             [
               'class' => 'img-fluid',

--- a/wp-theme-2018/shortcodes/epfl_card/view.php
+++ b/wp-theme-2018/shortcodes/epfl_card/view.php
@@ -34,7 +34,7 @@
         <picture>
         <?php echo wp_get_attachment_image(
           $image_id,
-          'thumbnail_16_9_large', // see functions.php
+          'thumbnail_16_9_large_40p', // see functions.php
           '',
           [
             'class' => 'img-fluid',

--- a/wp-theme-2018/shortcodes/epfl_cover/view.php
+++ b/wp-theme-2018/shortcodes/epfl_cover/view.php
@@ -8,7 +8,7 @@
     <picture>
       <?php echo wp_get_attachment_image(
         $image,
-        'thumbnail_16_9_large', // see functions.php
+        'thumbnail_16_9_large_80p', // see functions.php
         '',
         [
           'class' => 'img-fluid',

--- a/wp-theme-2018/shortcodes/hero/view.php
+++ b/wp-theme-2018/shortcodes/hero/view.php
@@ -14,7 +14,7 @@
       <picture>
         <?php echo wp_get_attachment_image(
           $data['image'],
-          'thumbnail_16_9_large', // see functions.php
+          'thumbnail_16_9_large_80p', // see functions.php
           '',
           [
             'class' => 'img-fluid'

--- a/wp-theme-2018/shortcodes/schools/view.php
+++ b/wp-theme-2018/shortcodes/schools/view.php
@@ -11,7 +11,7 @@
           <div class="col-sm-4">
             <a href="<?php echo $data['link'.$i]; ?>" class="card card-overlay link-trapeze-horizontal">
               <picture class="card-img">
-                <?php echo wp_get_attachment_image($data['image'.$i], 'thumbnail_16_9_large', '', ['class' => 'img-fluid']) ?>
+                <?php echo wp_get_attachment_image($data['image'.$i], 'thumbnail_16_9_large_40p', '', ['class' => 'img-fluid']) ?>
               </picture>
               <div class="card-img-overlay">
                 <h3 class="h4 card-title">


### PR DESCRIPTION
Lorsque l'on upload une image, WordPress créé un certain nombre de miniatures de tailles prédéfinies. Il est possible d'ajouter de nouvelles tailles via la fonction `add_image_size`, c'est ce qui a été fait pour le thème qu l'on utilise (ex) :
> add_image_size( 'thumbnail_16_9_large', 1920, 1080, ['center', 'center'] );

Ceci a pour effet de créer une miniature de 1920x1080 pour toutes les images supérieures à cette taille qui sont uploadées sur le site. Les informations `center` sont utilisées pour "cropper" l'image. Ce qui fait que même si l'image uploadée n'a pas le même ratio (16/9) que les 1920x1080, elle sera croppée pour faire la miniature.

La mention à `thumbnail_16_9_large` était ensuite utilisée comme paramètre pour la fonction permettant de renvoyer le code HTML (`wp_get_attachment_image`) pour afficher une image, avec un `srcset`.
Cette fonction fait 2 choses:
1. Elle recherche les miniatures de l'image qui ont le même ratio que celle donnée en paramètre (donc celle de 1920x1080)
1. Elle dit que l'image à utiliser pour des tailles d'écran jusqu'à 1920px doit être celle passée en paramètre (donc celle de 1920x1080)

Il y a 2 problèmes avec cette manière de faire :
1. Il n'y a qu'une seule autre miniature qui a le même ratio que l'image 1920x1080 et elle fait 384x216 (miniature built-in WordPress). Il y a donc peu de probabilité qu'elle soit utilisée lors d'un affichage...
1. On dit d'office d'utiliser l'image de 1920x1080 et donc jamais de miniature plus petite (ce qui n'est pas possible de toute façon vu qu'il n'y a en a qu'une et qu'elle est ridiculement petite...)

Ce que cette propose, c'est de: 
1. Ajouter 3 tailles de miniatures supplémentaires qui représentent respectivement 80%, 60% et 40% de la taille originale (1920x1080). 
1. Optimiser la sélection de l'image à afficher "par défaut" en donnant en paramètre à la fonction `wp_get_attachment_image` une taille de miniature un peu plus "optimisée" pour l'affichage. Chaque shortcode a été testé indépendemment afin de trouver la meilleure taille d'image à utiliser.

Au final, ça fait un peu plus d'espace utilisé sur le disque car un peu plus de miniatures (qui sont également optimisées par le plugin installé récemment) mais ça fait moins de MB transférés au client (on passe de 5.56MB à 3.21MB rien que pour les images pour la page d'accueil EPFL, test fait en local en reproduisant la page).

Et pour ce qui est des écrans avec une densité plus élevée au niveau des pixels, Le navigateur va automatiquement prendre des "miniatures" de tailles supérieure à l'image "par défaut" spécifiée.

**Après redéploiement du thème**
Il faudra repasser la commande suivante sur la totalité des sites:
`wp media regenerate --only-missing --yes`