### PR TITLE
Modify to enqueue script/style at the right moment (PHP Notice was generated)

### DIFF
--- a/wp-theme-2018/shortcodes/epfl_labs_search/controller.php
+++ b/wp-theme-2018/shortcodes/epfl_labs_search/controller.php
@@ -7,8 +7,17 @@
 
 add_action('epfl_labs_search_action', 'renderLabsSearch', 10, 3);
 
-wp_enqueue_script( 'epfl-labs-search-listjs', get_template_directory_uri() . '/shortcodes/epfl_labs_search/lib/list.min.js', ['jquery'], 1.5, true);
-wp_enqueue_style( 'epfl-labs-search-css', get_template_directory_uri() . '/shortcodes/epfl_labs_search/epfl-labs-search.css',false,'1.1','all');
+
+
+function epfl_labs_enqueue()
+{
+    wp_enqueue_script( 'epfl-labs-search-listjs', get_template_directory_uri() . '/shortcodes/epfl_labs_search/lib/list.min.js', ['jquery'], 1.5, true);
+    wp_enqueue_style( 'epfl-labs-search-css', get_template_directory_uri() . '/shortcodes/epfl_labs_search/epfl-labs-search.css',false,'1.1','all');
+}
+add_action( 'wp_enqueue_scripts', 'epfl_labs_enqueue' );
+
+
+
 
 /**
  * render the shortcode, mainly a form and his table


### PR DESCRIPTION
Durant le debug des problèmes sur les sites "disal" et "last", un `PHP Notice` traitant d'une mauvaise manière de faire pour l'utilisation de `wp_enqueue_script` et `wp_enqueue_style` apparaissait.
Cette PR permet de faire le "enqueue" des scripts/styles au bon moment et de s'affranchir du `PHP Notice`