### PR TITLE
Fix people image URL

### DIFF
--- a/wp-theme-2018/shortcodes/epfl_people/utils.php
+++ b/wp-theme-2018/shortcodes/epfl_people/utils.php
@@ -6,7 +6,7 @@
 function epfl_people_get_photo($person) {
     $photo_url = "";
     if ("1" == $person->people->photo_show) {
-        $photo_url = "https://people.epfl.ch/private/common/photos/links/" . $person->sciper;
+        $photo_url = "https://people.epfl.ch/private/common/photos/links/" . $person->sciper.".jpg";
     }
     return $photo_url;
 }


### PR DESCRIPTION
Suite à la modification faite en urgence tout récemment sur People, toutes les URL d'images devenaient incorrectes... car pas de redirections faites depuis ancien nom vers nouveau... donc "404"...
Ajout du ".jpg" à la fin de l'URL, afin que ça corresponde à la nouvelle manière de faire.

Une manère de faire plus endurante face aux changements du côté de People serait d'utiliser un WebService qui retourne l'URL de l'image d'une personne donnée... mais ça impliquerait autant d'appels à ce WebService qu'il n'y aurait de personnes dont on aurait besoin de la photo... donc pas optimum du tout.