### PR TITLE
update all news links

### DIFF
--- a/wp-theme-2018/shortcodes/epfl_news/utils.php
+++ b/wp-theme-2018/shortcodes/epfl_news/utils.php
@@ -8,8 +8,13 @@
 function epfl_news_get_url_channel($data) {
     $url_channel = "";
     if (count($data) > 0) {
-        $channel = $data[0]->channel->name;
-        $url_channel = "https://actu.epfl.ch/search/" . $channel;
+        $url_channel = "https://actu.epfl.ch/search/";
+        if (get_locale() == 'fr_FR') {
+            $url_channel .= "fr/";
+        } else {
+            $url_channel .= "en/";
+        }
+        $url_channel .= $data[0]->channel->name;
     }
     return $url_channel;
 }


### PR DESCRIPTION
Mettre à jour le lien "Toutes les actualités" afin de permettre de conserver la langue de navigation de l'utilisateur.

En effet, une modification a été fait dans l'outil actualités. 
**Exemple:** https://actu.epfl.ch/search/fr/enac
Sert une page avec toutes les news du canal enac et settant la langue de l'utilisateur à fr


