### PR TITLE
Shortcode news : visual_url dimension change

### DIFF
--- a/wp-theme-2018/shortcodes/epfl_news/utils.php
+++ b/wp-theme-2018/shortcodes/epfl_news/utils.php
@@ -68,7 +68,7 @@ function epfl_news_get_subtitle($news) {
  * $news: news to display
  */
 function epfl_news_get_visual_url($news) {
-    return substr($news->visual_url, 0, -11) . '1296x728.jpg';
+    return $news->visual_url;
 }
 
 /**


### PR DESCRIPTION
L'API REST de actu.epfl.ch va bientôt servir des images aux dimensions 1440x810.

Modification du shortcode en conséquence