### PR TITLE
Fix css bug for memento listing without highlight element

### DIFF
--- a/wp-theme-2018/shortcodes/epfl_memento/view.php
+++ b/wp-theme-2018/shortcodes/epfl_memento/view.php
@@ -286,7 +286,7 @@ $count++;
 </div>
 <?php elseif ("4" === $template): // TEMPLATE LISTING WITHOUT HIGHLIGHT ?>
 
-<div class="list-group">
+<div class="container list-group" style="padding-left: 16px">
 <?php
     if (!(bool) $data) {
       echo '<div><h3>';


### PR DESCRIPTION
Pour le shortcode memento listing sans mise en valeur du 1er event, la largeur de div étant trop petite (comme il y avait le First event hightlighté). 