### PR TITLE
Correction du bug d'affichage de l'adminbar

### DIFF
--- a/wp-theme-2018/footer.php
+++ b/wp-theme-2018/footer.php
@@ -24,8 +24,8 @@
 	?>
 	</div>
 </div>
+</div><!-- #page -->
 
 <?php wp_footer(); ?>
-</div><!-- #page -->
 </body>
 </html>


### PR DESCRIPTION
J'ai déplacé l'appel de la fonction wp_footer, ça doit toujours être le dernier élément avant la balise </body>. Comme elle se trouvait avant la fermeture du div #page, l'adminbar était placé à l'intérieur de ce div, ce qui causait le bug d'affichage.