### PR TITLE
Fix video including a old jQuery version

### DIFF
--- a/wp-theme-2018/functions.php
+++ b/wp-theme-2018/functions.php
@@ -144,10 +144,11 @@ function epfl_scripts() {
 	wp_enqueue_style( 'epfl-base', get_template_directory_uri().'/assets/css/base.css', array(), $vsn );
 	wp_enqueue_style( 'epfl-theme', get_template_directory_uri().'/theme/style.min.css', array(), $vsn );
 
-	wp_enqueue_script( 'epfl-js-jquery', 'https://code.jquery.com/jquery-3.3.1.min.js', array(), $vsn, true );
-	wp_enqueue_script( 'epfl-js-vendors', get_template_directory_uri() . '/assets/js/vendors.min.js', array(), $vsn, true );
-	wp_enqueue_script( 'epfl-js-vendors-bundle', get_template_directory_uri() . '/assets/js/vendors.bundle.js', array(), $vsn, true );
-	wp_enqueue_script( 'epfl-js', get_template_directory_uri() . '/assets/js/app.bundle.js', array('epfl-js-vendors-bundle'), $vsn, true );
+	wp_deregister_script( 'jquery' );
+	wp_register_script( 'jquery', "https://code.jquery.com/jquery-3.3.1.min.js", array(), $vsn );
+	wp_enqueue_script( 'epfl-js-vendors', get_template_directory_uri() . '/assets/js/vendors.min.js', ['jquery'], $vsn, true );
+	wp_enqueue_script( 'epfl-js-vendors-bundle', get_template_directory_uri() . '/assets/js/vendors.bundle.js', ['jquery'], $vsn, true );
+	wp_enqueue_script( 'epfl-js', get_template_directory_uri() . '/assets/js/app.bundle.js', ['jquery', 'epfl-js-vendors-bundle'], $vsn, true );
 }
 add_action( 'wp_enqueue_scripts', 'epfl_scripts' );
 

--- a/wp-theme-2018/functions.php
+++ b/wp-theme-2018/functions.php
@@ -144,11 +144,10 @@ function epfl_scripts() {
 	wp_enqueue_style( 'epfl-base', get_template_directory_uri().'/assets/css/base.css', array(), $vsn );
 	wp_enqueue_style( 'epfl-theme', get_template_directory_uri().'/theme/style.min.css', array(), $vsn );
 
-	wp_deregister_script( 'jquery' );
-	wp_register_script( 'jquery', "https://code.jquery.com/jquery-3.3.1.min.js", array(), $vsn );
-	wp_enqueue_script( 'epfl-js-vendors', get_template_directory_uri() . '/assets/js/vendors.min.js', ['jquery'], $vsn, true );
-	wp_enqueue_script( 'epfl-js-vendors-bundle', get_template_directory_uri() . '/assets/js/vendors.bundle.js', ['jquery'], $vsn, true );
-	wp_enqueue_script( 'epfl-js', get_template_directory_uri() . '/assets/js/app.bundle.js', ['jquery', 'epfl-js-vendors-bundle'], $vsn, true );
+	wp_register_script( 'epfl-js-jquery', "https://code.jquery.com/jquery-3.3.1.min.js", array(), $vsn );
+	wp_enqueue_script( 'epfl-js-vendors', get_template_directory_uri() . '/assets/js/vendors.min.js', ['epfl-js-jquery'], $vsn, true );
+	wp_enqueue_script( 'epfl-js-vendors-bundle', get_template_directory_uri() . '/assets/js/vendors.bundle.js', ['epfl-js-jquery'], $vsn, true );
+	wp_enqueue_script( 'epfl-js', get_template_directory_uri() . '/assets/js/app.bundle.js', ['epfl-js-jquery', 'epfl-js-vendors-bundle'], $vsn, true );
 }
 add_action( 'wp_enqueue_scripts', 'epfl_scripts' );
 

--- a/wp-theme-2018/functions.php
+++ b/wp-theme-2018/functions.php
@@ -358,7 +358,6 @@ function get_epfl_home_url () {
 	}
 }
 
-
 /**
  * Remove <p></p> tags around <img src="" alt=""> inputed in the wysiwyg
  */
@@ -366,3 +365,20 @@ function filter_ptags_on_images($content){
    return preg_replace('/<p>\s*(<a .*>)?\s*(<img .* \/>)\s*(<\/a>)?\s*<\/p>/iU', '\1\2\3', $content);
 }
 add_filter('the_content', 'filter_ptags_on_images');
+
+/**
+ * Remove the WP jquery from video shortcode, as we are already using jQuery 3.x
+ * and it create some incompatiblities, like crashing gallery shortcodes in the same page
+ */
+function wp_video_shortcode_without_jquery( $output, $atts, $video, $post_id, $library ) {
+
+	if (!is_admin()) {
+		wp_deregister_script('jquery');
+		# it may be already loaded, but in case it's not :
+		wp_enqueue_script('epfl-js-jquery');
+	}
+
+	return $output;
+}
+
+add_filter( 'wp_video_shortcode', 'wp_video_shortcode_without_jquery', 10, 5);


### PR DESCRIPTION
Remove the jquery depencies from video shortcode, so we don't generate conflicts when we have a gallery on the same page.

Forcing jQuery 3.x on video may have some side effects in the future. At the moment, it works as intended, so we will see if this need a better fix.