### PR TITLE
People: Uniformize phones number

### DIFF
--- a/wp-theme-2018/shortcodes/epfl_people/utils.php
+++ b/wp-theme-2018/shortcodes/epfl_people/utils.php
@@ -19,6 +19,27 @@ function epfl_people_get_phones($person) {
     foreach($person->unites as $current_unit) {
         $phones = array_merge($phones, array_filter($current_unit->phones));
     }
+
+    /* Looping through phone numbers to reformat them to have same format as the one on https://www.local.ch,
+        EX: +41 21 693 22 24 */
+    foreach($phones as $key => $phone){
+        /* If short format (ex: 32224) */
+        if(preg_match('/^([0-9])([0-9]{2,2})([0-9]{2,2})$/', $phone, $matches) === 1)
+        {
+            unset($matches[0]); // remove full phone number (equivalent to $phone)
+            $phones[$key] = "+41 21 69".implode(" ", $matches);
+        }
+        /* if long format without international (ex: 0216932224) */
+        elseif(preg_match('/^([0-9])([0-9]{2,2})([0-9]{3,3})([0-9]{2,2})([0-9]{2,2})$/', $phone, $matches) === 1)
+        {
+            unset($matches[0]); // remove full phone number (equivalent to $phone)
+            unset($matches[1]); // remove first digit (0) before local indentifier
+            $phones[$key] = "+41 ".implode(" ", $matches);
+        }
+        
+        /* There's no other condition to reformat because normally there is no other format in people.epfl.ch */
+    }
+
     return array_unique($phones);
 }
 

--- a/wp-theme-2018/shortcodes/epfl_people/view.php
+++ b/wp-theme-2018/shortcodes/epfl_people/view.php
@@ -1,4 +1,5 @@
 <?php
+
   require_once('utils.php');
   $persons = get_query_var('epfl_people_persons');
   $from = get_query_var('epfl_people_from');
@@ -31,7 +32,7 @@
         <a href="<?php echo esc_url($people_url) ?>" class="contact-list-item" itemprop="name"><?php echo esc_attr($person->prenom) ?> <?php echo esc_attr($person->nom) ?></a>
         <p class="contact-list-item m-0 text-muted" itemprop="jobTitle"><?php echo esc_html($function) ?></p>
         <a class="contact-list-item text-muted" href="mailto:<?php echo esc_attr($person->email) ?>" itemprop="email"><?php echo esc_attr($person->email) ?></a>
-        <a class="contact-list-item text-muted" href="tel:<?php echo esc_html($phones[0]) ?>" itemprop="telephone"><?php if ($phones[0]): ?>+41 21 69 <b><?php echo esc_html($phones[0]) ?></b><?php endif ?></a>
+        <a class="contact-list-item text-muted" href="tel:<?php echo esc_html(str_replace(" ", "", $phones[0])) ?>" itemprop="telephone"><?php if ($phones[0]): ?><b><?php echo esc_html($phones[0]) ?></b><?php endif ?></a>
         <a class="contact-list-item text-muted" href="<?php echo esc_url($room_url) ?>" itemprop="workLocation"><?php echo esc_html($room) ?></a>
     </div>
     <?php endforeach; ?>
@@ -42,6 +43,7 @@
     <?php endif; ?>
     <?php
       foreach($persons as $index => $person):
+
         $photo_url  = epfl_people_get_photo($person);
         $phones     = epfl_people_get_phones($person);
         $function   = epfl_people_get_function($person, $from);
@@ -79,7 +81,7 @@
               <a class="btn btn-block btn-primary mb-2" href="mailto:<?php echo esc_attr($person->email) ?>"><?php echo esc_html($person->email) ?></a>
               <?php endif ?>
               <?php if ($phones[0]): ?>
-              <a class="btn btn-block btn-secondary" href="tel:+412169<?php echo esc_html($phones[0]) ?>">+41 21 69 <?php echo esc_html($phones[0]) ?></a>
+              <a class="btn btn-block btn-secondary" href="tel:<?php echo esc_html(str_replace(" ", "", $phones[0])) ?>"><?php echo esc_html($phones[0]) ?></a>
               <?php endif ?>
             </div>
         </div>


### PR DESCRIPTION
Uniformisation des numéros de téléphone venant de People. Il y en a certains qui sont au format "école court" : 31234 et d'autre, qui ne sont pas dans l'école et ceux-ci sont donc 0221234567 (ex pour Genève)

**AVANT** (cf problème remonté dans INC0297001)
- les formats courts étaient appondu à un préfixe donné: `+41 21 69 ` (Ex: `+41 21 69 31234`)
- les formats longs étaient aussi appondu au même préfixe, ex: `+41 21 69 0221234567`

**MAINTENANT** (dans cette PR)
- Uniformisation pour coller à la manière dont les nos de téléphone sont affichés normalement dans les annuaires et sur le net.
- Les formats courts deviennent : `+41 21 693 12 34`
- Les formats longs deviennent: `+41 22 123 45 67`

