### PR TITLE
Add `epfl_home_url` option to change home URL in header and breadcrumb

### DIFF
--- a/wp-theme-2018/functions.php
+++ b/wp-theme-2018/functions.php
@@ -349,7 +349,7 @@ function root_menu_overrides_enabled () {
  */
 function get_epfl_home_url () {
 	$current_language = get_current_language();
-	$epfl_root = 'https://www.epfl.ch/';
+	$epfl_root = get_option('epfl_home_url') ? : 'https://www.epfl.ch/';
 
 	if ($current_language === 'fr') {
 		return $epfl_root . 'fr/';


### PR DESCRIPTION
This makes WordPress re-rootable, which is useful for test environments.