### PR TITLE
Fix not using selected homepage as parent page

### DIFF
--- a/wp-theme-2018/menus/blog-posts.php
+++ b/wp-theme-2018/menus/blog-posts.php
@@ -109,9 +109,8 @@ function set_homepage_or_root($menu_entry, &$items) {
         # get the good translated version, if any, and if Polylang installed
         if( function_exists('pll_get_post') ) {
             $translated_static_home_page_selected_id = pll_get_post($home_page_id);
+            $home_page_id = $translated_static_home_page_selected_id;
         }
-
-        $home_page_id = $translated_static_home_page_selected_id;
 
         if ( $home_page_id && !empty($items) ) {  // a selected homepage and a menu, how nice !
             # check if this homepage menu entry page is in the menu, because we need it now
@@ -168,9 +167,8 @@ function set_best_parent_for_blog_entry(&$items) {
         # and if Polylang is installed
 	    if( function_exists('pll_get_post') ) {
             $translated_static_posts_page_selected_id = pll_get_post($static_posts_page_selected_id);
+            $static_posts_page_selected_id = $translated_static_posts_page_selected_id;
         }
-
-        $static_posts_page_selected_id = $translated_static_posts_page_selected_id;
     }
 
     if ( $static_posts_page_selected_id && !empty($items) ) {  // a selected posts page and a menu, how nice !
@@ -281,7 +279,7 @@ function provide_custom_nav_menu_items_for_blog($items, $menu, $args = array()) 
 
         return $items;
     }
-    elseif (is_archive()) {
+    elseif (is_archive() || get_queried_object()) {
 
         $parent_menu_item = set_best_parent_for_blog_entry($items);
         $current_post_menu_item = build_new_item_menu_from_post(get_post(), $parent_menu_item->ID, $items);

--- a/wp-theme-2018/menus/utils.php
+++ b/wp-theme-2018/menus/utils.php
@@ -69,6 +69,10 @@ function has_static_posts_page_selected()
     return $static_posts_page_id;
 }
 
+/**
+ * Check if the user has set a homepage (settings->Reading->Your homepage displays)
+ * Return the id if this is the case, or False
+ */
 function has_home_page_selected()
 {
     static $static_home_page_id = null;  # cache it because the db hit
@@ -109,6 +113,5 @@ function error_log_useful_debugging_information() {
     //error_log("filters: " . var_export( $wp_filter['wp_get_nav_menu_items'], True));
 
     // Useful little line
-    //var_dump(array_map(create_function('$o', 'return $o->title;'), $items));  // deprecated
     //var_dump(array_map(function($o) {return $o->title;}, $items));
 }

--- a/wp-theme-2018/menus/utils.php
+++ b/wp-theme-2018/menus/utils.php
@@ -69,6 +69,22 @@ function has_static_posts_page_selected()
     return $static_posts_page_id;
 }
 
+function has_home_page_selected()
+{
+    static $static_home_page_id = null;  # cache it because the db hit
+
+    if (is_null($static_home_page_id)){
+        $show_on_front = get_option('show_on_front');
+        $front_page_id = get_option('page_on_front');
+        if ($show_on_front == 'page' && isset($front_page_id)) {
+            $static_home_page_id = $front_page_id;
+        } else {
+            $static_home_page_id = False;
+        }
+    }
+    return $static_home_page_id;
+}
+
 function error_log_useful_debugging_information() {
     error_log("has_the_blog_post_selected: " . var_export(has_static_posts_page_selected(), True));
     error_log("is_home: " . var_export(is_home(), True));

--- a/wp-theme-2018/sidebar.php
+++ b/wp-theme-2018/sidebar.php
@@ -19,8 +19,10 @@ $classes = '';
 $items = wp_get_nav_menu_items(get_current_menu_slug());
 $current_menu_entry = get_menu_entry_from_element_id($items, get_currently_viewed_element_id());
 
-if ($current_menu_entry === false || $current_menu_entry->menu_item_parent == 0 || is_home()) {
-	$classes = 'current-menu-parent';
+if (get_queried_object()) {  // only when we are looking at an object
+	if ($current_menu_entry === false || $current_menu_entry->menu_item_parent == 0 || is_home()) {
+		$classes = 'current-menu-parent';
+	}
 }
 
 ?>


### PR DESCRIPTION
Cette PR vise à ce que les pages de détail d'un post et les pages de listing des posts se retrouvent correctement dans le menu, lorsque le site n'a pas configuré son menu correctement pour ces éléments de blogs.

Actuellement, on peut remarquer le problème ici :
https://www.epfl.ch/labs/alice/category/research/
Dans le breadcrump (et les menus), on voit 
"Laboratoires > Articles", avec cette PR on aura on "Laboratoires > ALICE > Articles"